### PR TITLE
added JC scripts for downloading and procesing various genetics dsets

### DIFF
--- a/scripts/plink_download_and_processing_scripts/1000G_HGDP_filters_general.sh
+++ b/scripts/plink_download_and_processing_scripts/1000G_HGDP_filters_general.sh
@@ -1,0 +1,51 @@
+#TO DO IT ASIDE FROM THE OTHER DATASETS 
+#COULD MAKE VARY THE LD PRUNING FILTER STEP
+
+#LD PRUNING STEP : 100 50 0.05
+
+for f in $(seq 1 22)
+do
+echo '#!/bin/bash' > pruning.chr$f.sh
+echo "module load StdEnv/2020
+module load plink/1.9b_6.21-x86_64
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc --maf 0.01 --out gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01 --real-ref-alleles --make-bed
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01 --indep-pairwise 100 50 0.05 --out gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.prune100_50_0.05
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01 --extract gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.prune100_50_0.05.prune.in --make-bed --out gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05 --real-ref-alleles" >> pruning.chr$f.sh
+
+sbatch --chdir $(pwd) --account=def-hussinju --time=2:00:00 --output=pruning.chr$f.%j.out --error=pruning.chr$f.%j.err --mem=40G --cpus-per-task=6 pruning.chr$f.sh
+done
+
+
+cp [path to lowcomplexity regions in GRCh38]/{HG38.Anderson2010.bed,HLA_region.bed} .
+cat *.bed > lowComplexity.HLA.bed
+sed -i 's/chr//' lowComplexity.HLA.bed
+awk '{print $0"\t"NR}' lowComplexity.HLA.bed > lowComplexity.HLA.2.bed
+
+for f in $(seq 1 22)
+do 
+echo "../gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05" >> allFiles.txt
+done
+
+plink --merge-list allFiles.txt --real-ref-alleles --make-bed --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05
+
+
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05 --exclude range lowComplexity.HLA.2.bed --real-ref-alleles --make-bed --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05.noHLA.woLowComplexity
+
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05.noHLA.woLowComplexity --recode vcf --real-ref-alleles --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.01.LDpruned100_50_0.05.noHLA.woLowComplexity.recoded
+
+
+
+mkdir forRaph
+for f in $(seq 1 22)
+do 
+echo "../gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05" >> allFiles_maf5.txt
+done
+
+plink --merge-list allFiles_maf5.txt --real-ref-alleles --make-bed --out forRaph/gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05
+
+
+cd forRaph
+
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05 --exclude range ../lowComplexity.HLA.2.bed --real-ref-alleles --make-bed --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05.noHLA.woLowComplexity
+
+plink --bfile gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05.noHLA.woLowComplexity --recode vcf --real-ref-alleles --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.maf0.05.noHLA.woLowComplexity.recoded

--- a/scripts/plink_download_and_processing_scripts/1000G_HGDP_processing_general.sh
+++ b/scripts/plink_download_and_processing_scripts/1000G_HGDP_processing_general.sh
@@ -1,0 +1,94 @@
+#1000G + HGDP dataset pre-filtering steps
+
+cd [working directory]
+
+#1 Keep PASS variants and SNPs only
+for f in $(seq 1 22)
+do
+i=gnomad.genomes.v3.1.2.hgdp_tgp.chr$f
+echo '#!/bin/bash' > chr$f.PASS.sh
+echo "module load [bcftools 1.9 module]
+bcftools view --threads 2 -Oz -f PASS -o $i.PASSfiltered.vcf.gz 1000G_HGDP_merged_dataset/$i.vcf.bgz
+zcat $i.PASSfiltered.vcf.gz | head -n 5000 | grep \"#\" > $i.PASSfiltered.header
+zcat $i.PASSfiltered.vcf.gz | grep -v \"#\" | cut -f 1-5 | awk '{print \$1\"\t\"\$2\"\t\"\$1\":\"\$2\":\"\$4\":\"\$5\"\t\"\$4\"\t\"\$5}'> $i.PASSfiltered.5cols
+zcat $i.PASSfiltered.vcf.gz | grep -v \"#\" | cut -f 6- > $i.PASSfiltered.lastCols
+paste $i.PASSfiltered.5cols $i.PASSfiltered.lastCols > $i.PASSfiltered.noHeader
+rm $i.PASSfiltered.5cols $i.PASSfiltered.lastCols
+awk '{if(length(\$4)==1 && length(\$5)==1)print}' $i.PASSfiltered.noHeader > $i.PASSfiltered.noHeader.onlySNPs
+cat $i.PASSfiltered.header $i.PASSfiltered.noHeader.onlySNPs > $i.PASSfiltered.newIDs.onlySNPs.vcf
+rm $i.PASSfiltered.header $i.PASSfiltered.noHeader.onlySNPs $i.PASSfiltered.noHeader
+bgzip $i.PASSfiltered.newIDs.onlySNPs.vcf
+tabix -p vcf $i.PASSfiltered.newIDs.onlySNPs.vcf.gz" >> chr$f.PASS.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=chr$f.PASS.%j.out --error=chr$f.PASS.%j.err --mem=40G --cpus-per-task=2  chr$f.PASS.sh
+done
+
+
+
+
+
+
+#2 For multi-allelic variants, keep only the one allele with the highest MAF.
+#Do after the QC filters : HWE 1e-6 and 5% missing rate
+
+for f in $(seq 1 22)
+do 
+i=gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs
+echo '#!/bin/bash' > chr$f.filterPos.sh
+echo "module load [R 4.1.0 module] [plink 1.9 module]
+plink --vcf $i.vcf.gz --make-bed --real-ref-alleles --out $i --double-id
+plink --bfile $i --freq --out $i.FREQ --double-id
+
+paste <(sed -e 's/^ \\+//' -e 's/ \\+/\\t/g' $i.FREQ.frq) <(awk '{print \$1\"_\"\$4}' $i.bim | sed '1s/^/Position\n/') > $i.FREQ.frq.withPosCol
+
+j=$i.FREQ.frq.withPosCol
+echo \"library(dplyr)
+library(data.table)
+
+table_freq=read.table(\\\"\$j\\\",h=T,sep=\\\"\t\\\")
+table_freq_2=arrange(table_freq,Position,desc(MAF))
+table_freq_3=distinct(table_freq_2,Position,.keep_all=1)
+write.table(table_freq_3,file=\\\"\$j.noDuplicate\\\",sep=\\\"\t\\\",quote=F,row.names=F)\" > \$j.removeDup.R
+
+R CMD BATCH \$j.removeDup.R
+
+cut -f 2 $i.FREQ.frq.withPosCol.noDuplicate > $i.FREQ.frq.withPosCol.noDuplicate.ids
+
+
+# Extract resulting selected positions and do the QC steps HWE and Missing 5%
+plink --bfile $i --extract $i.FREQ.frq.withPosCol.noDuplicate.ids --geno 0.05 --make-bed --out $i.noDuplicatePos.noMiss5perc --real-ref-alleles --double-id" >> chr$f.filterPos.sh
+
+sbatch --chdir $(pwd) --account=def-hussinju --time=5:00:00 --output=chr$f.filterPos.%j.out --error=chr$f.filterPos.%j.err --mem=40G --cpus-per-task=12  chr$f.filterPos.sh
+done
+
+
+#3 Remove chr in front of the chromosome names in the resulting bim files
+for f in $(seq 1 22)
+do
+cp gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.bim gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.bim.bkp
+sed -i 's/chr//' gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.bim
+done
+
+
+
+
+
+#Optional : 
+#4 Do the overlap with the GSA arrays 
+mkdir overlap_1000G_CAG_MHI
+cd overlap_1000G_CAG_MHI
+
+#1000G.2504_WGS30x.GSA17k_MHI.intersectGSA.miss10perc.maf0.05.pruned.autosomes.noHLA.bim
+cp [PATH TO THE 1000G 2504 WGS30X bim files used for another project (DietNet)] .
+
+for f in $(seq 1 22)
+do
+plink --bfile ../gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc --extract 1000G.2504_WGS30x.GSA17k_MHI.intersectGSA.miss10perc.maf0.05.pruned.autosomes.noHLA.bim --make-bed --out gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.match1000G_GSAs_dietnet --real-ref-alleles
+done
+
+
+
+for f in $(seq 1 22) ; do echo "gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.match1000G_GSAs_dietnet" >> hgpg_tgp.files.txt; done
+
+plink --merge-list hgpg_tgp.files.txt --real-ref-alleles --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.match1000G_GSAs_dietnet --make-bed
+
+rm gnomad.genomes.v3.1.2.hgdp_tgp.chr*

--- a/scripts/plink_download_and_processing_scripts/MHI_Cartagene_preprocessing_general.sh
+++ b/scripts/plink_download_and_processing_scripts/MHI_Cartagene_preprocessing_general.sh
@@ -1,0 +1,199 @@
+#MHI and Cartagene preprocessing and phasing for Matt's project
+
+cd [path to working directory]
+
+#copy files from Camille's Dietnet temp files where those datasets were processed 
+
+#MHI
+cp [MHI_FILE].{bed,bim,fam} .
+
+#Cartagene
+ cp [CaG_FILE].{bed,bim,fam} .
+
+#LOAD PLINK MODULES
+module load [plink 1.9 module]
+
+#1 Extract the selected positions and do the QC steps HWE and Missing 5%
+for f in *.bim ; 
+do
+f=${f/\.bim/}
+plink --bfile $f --hwe 0.000001 midp --geno 0.05 --make-bed --out $f.QC --real-ref-alleles
+done
+
+#do intersection between datasets
+cut -f 2 [CaG_prefix].QC.bim [MHI_prefix].QC.bim | sort | uniq -c | awk '{if($1==2) print $2}' > intersection_mhi_cag17k.txt
+#511916 positions
+
+
+
+#2 Cleanup
+mkdir log_files
+mv *.log log_files
+
+for f in *.QC.bim ; do cp $f $f.bkp ; done
+
+
+#Rename the SNP ids
+for f in *.QC.bim ; do awk '{print $1"\t"$1":"$4":"$6":"$5"\t"$3"\t"$4"\t"$5"\t"$6}' $f.bkp > $f ; done
+
+#remove samples with too many missing data
+for f in *.QC.bim ; do f=${f/\.bim/}  ; plink --bfile $f --mind 0.5 --make-bed --out $f.maxMiss0.5 --real-ref-alleles ; done
+
+#0 indiv removed
+
+#convert in vcf format
+for f in *.QC.maxMiss0.5.bim ; do f=${f/\.bim/} ; plink --bfile $f --recode vcf --out $f --real-ref-alleles ; done
+for f in *.vcf ; do sed -i -e 's/ID=23/ID=X/' -e 's/ID=24/ID=Y/' -e 's/^23/X/' -e 's/^24/Y/' -e 's/\t23:/\tX:/' -e 's/\t24:/\tY:/' $f ; done
+
+
+
+
+
+
+
+
+mkdir noINDELs_fixref_vcf
+
+for f in *.QC.maxMiss0.5.bim
+do
+f=${f/\.bim/}
+echo '#!/bin/bash' > $f.fixref.sh
+echo "module load tabix
+module load [bcftools 1.9 module] [plink 1.9 module]
+
+export BCFTOOLS_PLUGINS=[path to bcftools 1.9 plugins]
+
+reference=[path to GRCh38 fasta refence]
+bcftools +fixref $f.vcf --threads 48 -o noINDELs_fixref_vcf/$f.fixref.vcf.gz -Oz -- -f \$reference -m flip -d 2> noINDELs_fixref_vcf/$f.fixref.log" >> $f.fixref.sh
+
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=$f.fixref.%j.out --error=$f.fixref.%j.err --mem=200G --cpus-per-task=48 $f.fixref.sh
+done
+
+
+cd noINDELs_fixref_vcf
+module load htslib
+
+
+tabix -p vcf [CaG_prefix].QC.maxMiss0.5.fixref.vcf.gz
+tabix -p vcf [MHI_prefix].QC.maxMiss0.5.fixref.vcf.gz
+
+
+
+#REMOVE BAD POSITIONS (TOPMED) :
+
+for f in *.QC.maxMiss0.5.fixref.vcf.gz
+do
+f=${f/\.vcf\.gz/}
+echo '#!/bin/bash' > $f.wrayner.sh
+echo "module load [plink1.9]
+plink --vcf $f.vcf.gz --make-bed --real-ref-alleles --out $f.PLINK
+plink --bfile $f.PLINK --freq --out $f.PLINK.FREQ --real-ref-alleles
+topmed_path=[path to TOPMED reference file]
+path_wrayner_script=[path to HRC-1000G-check-bim script]
+perl \$path_wrayner_script -b $f.PLINK.bim -f $f.PLINK.FREQ.frq -r \$topmed_path -h" >> $f.wrayner.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=10:00:00 --output=$f.wrayner.%j.out --error=$f.wrayner.%j.err --mem=40G --cpus-per-task=1  $f.wrayner.sh
+done
+
+mkdir wrayner_tmp_files
+mv Strand-Flip* Position* Chromosome* Run-plink.sh LOG* ID* FreqPlot* Force-Allele1* wrayner_tmp_files/
+
+
+for f in *.QC.maxMiss0.5.fixref.vcf.gz
+do
+f=${f/\.vcf\.gz/}
+echo "module load [bcftools 1.9 module]
+bcftools filter --threads 12 -e 'ID=@Exclude-$f.PLINK-HRC.txt' -Oz -o $f.noBadPosTopMed.vcf.gz $f.vcf.gz" > filterBadSNPs.sh
+bash filterBadSNPs.sh
+tabix -p vcf $f.noBadPosTopMed.vcf.gz
+done
+
+
+
+#NEED TO RENAME THE SNP ids 
+for f in *.noBadPosTopMed.vcf.gz
+do
+i=$(echo $f| sed -e 's/.*\///' -e 's/.vcf.gz//')
+echo '#!/bin/bash' > $i.ids.sh
+echo "module load [bcftools 1.9 module]
+zcat $f | head -n 5000 | grep \"#\" > \$SLURM_TMPDIR/$i.header
+zcat $f | grep -v \"#\" | cut -f 1-5 | awk '{print \$1\"\t\"\$2\"\t\"\$1\":\"\$2\":\"\$4\":\"\$5\"\t\"\$4\"\t\"\$5}'> \$SLURM_TMPDIR/$i.5cols
+zcat $f | grep -v \"#\" | cut -f 6- > \$SLURM_TMPDIR/$i.lastCols
+paste \$SLURM_TMPDIR/$i.5cols \$SLURM_TMPDIR/$i.lastCols > \$SLURM_TMPDIR/$i.noHeader
+rm \$SLURM_TMPDIR/$i.5cols \$SLURM_TMPDIR/$i.lastCols
+cat \$SLURM_TMPDIR/$i.header \$SLURM_TMPDIR/$i.noHeader > $i.newIDs.vcf
+bgzip $i.newIDs.vcf
+tabix -p vcf $i.newIDs.vcf.gz
+rm \$SLURM_TMPDIR/$i.header \$SLURM_TMPDIR/$i.lastCols" >> $i.ids.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=$i.ids.%j.out --error=$i.ids.%j.err --mem=40G --cpus-per-task=6 $i.ids.sh
+done
+
+
+
+mkdir common_1000G_HGDP
+cd common_1000G_HGDP
+
+#GET THE INTERSECT WITH 1000G + HGDP GRCh38 phase3 phased dataset
+#link to 1000G dataset withj positions renamed and positions filtered for PASS criteria, duplicated and multiallelic positions also accounted for. Only SNPs retained and removed positions with more than 5% missing rate.
+#new prefix for the files gnomad.genomes.v3.1.2.hgdp_tgp.chr*.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.vcf.gz
+ln -s [path to 1000G_HGDP] 1000G_HGDP_GRCh38
+
+#find overlap with MHI and CaG combined files
+for f in ../*.newIDs.vcf.gz
+do
+f=${f/\.vcf\.gz/}
+plink --vcf $f.vcf.gz --write-snplist --out $f.ids.txt
+done
+
+#do intersection and get unique set of positions that are present in both datasets
+cat ../*.snplist | sort | uniq -d > intersection_mhni_cag17k.txt
+
+for f in $(seq 1 22)
+do
+echo '#!/bin/bash' > $f.extractCommon.sh
+
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+plink --bfile 1000G_HGDP_GRCh38/[1000G_HGDP per chromosome prefix - f variable] --extract intersection_mhni_cag17k.txt --make-bed --real-ref-alleles --out [1000G_HGDP per chromosome prefix - f variable].commonMHI_CaG17k 
+tabix -p vcf [1000G_HGDP per chromosome prefix - f variable].commonMHI_CaG17k.vcf.gz" >> $f.extractCommon.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=5:00:00 --output=$f.extractCommon.%j.out --error=$f.extractCommon.%j.err --mem=40G --cpus-per-task=6 $f.extractCommon.sh
+done
+
+
+
+
+#Filters on 1000G
+
+for f in $(seq 1 22)
+do
+echo '#!/bin/bash' > $f.missing10perc.Maf0.05_pruning.sh
+prefix=[1000G_HGDP per chromosome prefix - f variable].commonMHI_CaG17k
+
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+plink --bfile $prefix --out $prefix.miss10perc.maf0.05 --make-bed --real-ref-alleles --geno 0.1 --maf 0.05
+plink --bfile $prefix.miss10perc.maf0.05 --indep-pairwise 50 5 0.5 --out $prefix.miss10perc.maf0.05.LDpruning
+plink --bfile $prefix.miss10perc.maf0.05 --extract $prefix.miss10perc.maf0.05.LDpruning.prune.in --real-ref-alleles --out $prefix.miss10perc.maf0.05.LDpruned --make-bed" >> $f.missing10perc.Maf0.05_pruning.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=1:00:00 --output=$f.missing10perc.Maf0.05_pruning.%j.out --error=$f.missing10perc.Maf0.05_pruning.%j.err --mem=40G --cpus-per-task=6 $f.missing10perc.Maf0.05_pruning.sh
+done
+
+#remove Low complexity and HLA
+#those files should be provided
+cp [path to lowcomplexity regions in GRCh38]/{HG38.Anderson2010.bed,HLA_region.bed} .
+cat HLA_region.bed HG38.Anderson2010.bed |sed 's/chr//' > lowComplexity_HLA.bed
+awk '{print $0"\tregion"NR}' lowComplexity_HLA.bed > lowComplexity_HLA.txt
+
+
+for f in $(seq 1 22) ; do echo "[1000G_HGDP per chromosome prefix - f variable].commonMHI_CaG17k.miss10perc.maf0.05.LDpruned" >> allFiles.1000G_HGDP.txt ; done
+
+plink --merge-list allFiles.1000G_HGDP.txt --make-bed --real-ref-alleles --out [1000G_HGDP prefix].commonMHI_CaG17k.miss10perc.maf0.05.LDpruned
+
+prefix=[1000G_HGDP prefix].commonMHI_CaG17k
+plink --bfile $prefix.miss10perc.maf0.05.LDpruned --make-bed --real-ref-alleles --exclude range lowComplexity_HLA.txt --out $prefix.miss10perc.maf0.05.LDpruned.woLowComplexity_noHLA
+
+
+
+#Do last filters on MHI and CaG
+for f in *.QC.maxMiss0.5.fixref.noBadPosTopMed.newIDs.vcf.gz 
+do
+f=$(echo $f | sed -e 's/\.\.\///' -e 's/\.vcf\.gz//')
+plink --vcf ../$f.vcf.gz --extract [1000G_HGDP prefix].commonMHI_CaG17k.miss10perc.maf0.05.LDpruned.woLowComplexity_noHLA.bim --make-bed --real-ref-alleles --out $f.common1000G_HGDP.woLowComplexity_noHLA
+done
+

--- a/scripts/plink_download_and_processing_scripts/UKB_liftover_allcohort_general.sh
+++ b/scripts/plink_download_and_processing_scripts/UKB_liftover_allcohort_general.sh
@@ -1,0 +1,48 @@
+#working directory :
+cd [working directory]
+
+ln -s [path to ukbiobank plink files directory] plink
+
+
+#merge the entire set
+
+for f in $(seq 1 22)
+do
+echo "plink/ukb_chr${f}_v2" >> allFiles.txt 
+done
+
+
+echo '#!/bin/sh' > merge.sh 
+echo "module load [plink2 module]
+plink2 --pmerge-list allFiles.txt bfile --make-bed --real-ref-alleles --out ukb_v2" >> merge.sh 
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=10:00:00 --output=merge.%j.out --error=merge.%j.err --mem=100G --cpus-per-task=24 merge.sh
+
+
+mkdir liftover_GRCh38
+cd liftover_GRCh38/
+
+file=ukb_v2
+
+awk '{print "chr"$1"\t"$4-1"\t"$4"\t"$2"\t"$5"_"$6}' ../$file.bim > $file.hg19.pos.bed
+
+liftOver $file.hg19.pos.bed [path to chain files]/hg19ToHg38.over.chain $file.GRCh38.pos.bed $file.hg19.unmapped
+cut -f 4 $file.GRCh38.pos.bed  > tmp.toExtract.txt
+
+plink --bfile ../$file --extract tmp.toExtract.txt --out $file.hg19.liftOverCommon --make-bed --real-ref-alleles
+
+mkdir GRCh38
+cp $file.hg19.liftOverCommon.bed GRCh38/$file.liftOverCommon.GRCh38.bed
+cp $file.hg19.liftOverCommon.fam GRCh38/$file.liftOverCommon.GRCh38.fam
+
+
+sed 's/^chr//' $file.GRCh38.pos.bed | awk '{print $1"\t"$4"\t0\t"$3"\t"$5}' | rev | sed 's/_/\t/' | rev > GRCh38/$file.liftOverCommon.GRCh38.bim
+cd GRCh38
+
+
+plink --bfile $file.liftOverCommon.GRCh38 --make-bed --out $file.liftOverCommon.GRCh38.sorted --allow-extra-chr --real-ref-alleles
+
+#REMOVE INDELS
+awk '{if(length($5) == 1 && length($6)==1) print }' $file.liftOverCommon.GRCh38.sorted.bim | sed -e '/random/d' -e '/alt/d' > $file.liftOverCommon.GRCh38.sorted.SNPs.txt
+
+
+plink --bfile $file.liftOverCommon.GRCh38.sorted --make-bed --out $file.liftOverCommon.GRCh38.sorted.onlySNPs --extract $file.liftOverCommon.GRCh38.sorted.SNPs.txt --real-ref-alleles --allow-extra-chr

--- a/scripts/plink_download_and_processing_scripts/UKB_preprocessing_general.sh
+++ b/scripts/plink_download_and_processing_scripts/UKB_preprocessing_general.sh
@@ -1,0 +1,246 @@
+#UKB preprocessing and phasing for Matt's project
+#FROM LIFTOVER FILES containing SNPs only
+
+
+#Make sure to withdraw all individuals that need to be withdrawn
+grep -Fwf [path to file containing ids to be withdrawn] ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.fam > indivWithdrawn_20240613.txt
+
+plink --bfile ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs --remove indivWithdrawn_20240613.txt --make-bed --real-ref-alleles --out ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+
+
+
+prefix=ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+# Remove variant duplicates.  Keep the ones with the lowest missingness.
+module load [R 4.1.0 module]
+
+for i in $prefix.bim
+do
+i=${i/\.bim/}
+plink --bfile $i --missing --out $i.MISSING
+paste <(sed '1d' $i.MISSING.lmiss | awk '{print $2"\t"$5}') <(awk '{print $1"_"$4"_"$5"_"$6}' $i.bim) > $i.MISSING.lmiss.withPosCol
+
+sed -i '1s/^/SNP\tMISS\tPosition\n/' $i.MISSING.lmiss.withPosCol
+
+
+f=$i.MISSING.lmiss.withPosCol
+echo "library(dplyr)
+library(data.table)
+
+table_freq=read.table(\"$f\",h=T,sep=\"\t\")
+table_freq_2=arrange(table_freq,Position,MISS)
+table_freq_3=distinct(table_freq_2,Position,.keep_all=1)
+write.table(table_freq_3,file=\"$f.noSamePos\",sep=\"\t\",quote=F,row.names=F)" > $f.removeSame.R
+
+R CMD BATCH $f.removeSame.R
+
+plink -bfile $i --extract $i.MISSING.lmiss.withPosCol.noSamePos --make-bed --out $i.woSamePos --real-ref-alleles
+
+
+
+# For multi-allelic variants, keep only the one allele with the highest MAF.
+plink --bfile $i.woSamePos --freq --out $i.woSamePos.FREQ
+paste <(sed -e 's/^ \+//' -e 's/ \+/\t/g' $i.woSamePos.FREQ.frq) <(awk '{print $1"_"$4}' $i.woSamePos.bim | sed '1s/^/Position\n/') > $i.woSamePos.FREQ.frq.withPosCol
+
+f=$i.woSamePos.FREQ.frq.withPosCol
+echo "library(dplyr)
+library(data.table)
+
+table_freq=read.table(\"$f\",h=T,sep=\"\t\")
+table_freq_2=arrange(table_freq,Position,desc(MAF))
+table_freq_3=distinct(table_freq_2,Position,.keep_all=1)
+write.table(table_freq_3,file=\"$f.noDuplicate\",sep=\"\t\",quote=F,row.names=F)" > $f.removeDup.R
+
+R CMD BATCH $f.removeDup.R
+
+cut -f 2 $i.woSamePos.FREQ.frq.withPosCol.noDuplicate > $i.woSamePos.FREQ.frq.withPosCol.noDuplicate.ids
+
+
+#3.d. Extract the selected positions and do the QC steps HWE and Missing 5%
+plink --bfile $i.woSamePos --extract $i.woSamePos.FREQ.frq.withPosCol.noDuplicate.ids --hwe 0.000001 midp --geno 0.05 --make-bed --out $i.woSamePos.noDuplicatePos.QC --real-ref-alleles
+
+done
+
+
+
+# Cleanup
+mkdir log_files r_scripts
+rm *noDuplicate *.noDuplicate.ids *.withPosCol *.noSamePos *.imiss *.lmiss *.frq
+mv *.Rout *.log log_files
+mv *.R r_scripts
+
+
+for f in *.QC.bim ; do cp $f $f.bkp ; done
+
+
+#Rename the SNP ids
+for f in *.QC.bim ; do awk '{print $1"\t"$1":"$4":"$6":"$5"\t"$3"\t"$4"\t"$5"\t"$6}' $f.bkp > $f ; done
+
+#remove samples with too many missing data
+for f in *.QC.bim ; do f=${f/\.bim/}  ; plink --bfile $f --mind 0.5 --make-bed --out $f.maxMiss0.5 --real-ref-alleles ; done
+
+
+#convert in vcf format
+for f in *.QC.maxMiss0.5.bim ; do f=${f/\.bim/} ; plink --bfile $f --recode vcf --out $f --real-ref-alleles ; done
+
+
+mkdir noINDELs_fixref_vcf
+# Merged version
+
+echo '#!/bin/bash' > fixref.sh
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+
+prefix=ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+export BCFTOOLS_PLUGINS=[path to bcftool 1.9 plugins]
+
+
+bcftools +fixref \$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.vcf --threads 48 -o noINDELs_fixref_vcf/\$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz -Oz -- -f [path to GRCh38 fasta reference] -m flip -d 2> noINDELs_fixref_vcf/\$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.log" >> fixref.sh
+
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=fixref.%j.out --error=fixref.%j.err --mem=200G --cpus-per-task=48 fixref.sh
+
+cd noINDELs_fixref_vcf
+module load htslib
+tabix -p vcf $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz
+
+
+# Remove monomorphic sites
+module load [bcftools 1.9 module] [plink 1.9 module]
+
+plink --vcf $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz --freq --out $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz.FREQ
+
+awk '{if($5!=0)print $2}' $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz.FREQ.frq > polymorphs.ids
+
+
+echo '#!/bin/bash' > onlyPolymorph.sh 
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+
+prefix=ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+bcftools filter --threads 12 -i 'ID=@polymorphs.ids' -Oz -o \$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.vcf.gz \$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.vcf.gz
+tabix -p vcf \$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.vcf.gz" >> onlyPolymorph.sh 
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=onlyPolymorph.%j.out --error=onlyPolymorph.%j.err --mem=200G --cpus-per-task=12 onlyPolymorph.sh
+
+
+
+
+#REMOVE BAD POSITIONS (TOPMED) :
+
+prefix=ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+echo '#!/bin/bash' > $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.wrayner.sh
+
+echo "module load [plink 1.9 module]
+plink --vcf $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.vcf.gz --make-bed --real-ref-alleles --out $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK
+
+plink --bfile $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK --freq --out $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.FREQ --real-ref-alleles
+path_wrayner_script=[path to HRC-1000G-check-bim script]
+topmed_path=[path to TOPMED reference file]
+perl \$path_wrayner_script -b $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.bim -f $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.FREQ.frq -r \$topmed_path -h" >> $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.wrayner.sh
+
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=10:00:00 --output=$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.wrayner.%j.out --error=$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.wrayner.%j.err --mem=40G --cpus-per-task=1  $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.wrayner.sh
+
+
+
+
+mkdir wrayner_tmp_files
+
+mv Strand-Flip* Position* Chromosome* Run-plink.sh LOG* ID* FreqPlot* Force-Allele1* wrayner_tmp_files/
+
+echo "module load [bcftools 1.9 module]
+bcftools filter --threads 12 -e 'ID=@Exclude-$prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK-HRC.txt' -Oz -o $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.vcf.gz $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.vcf.gz" > filterBadSNPs.sh
+
+bash filterBadSNPs.sh
+
+tabix -p vcf $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.vcf.gz
+
+
+prefix=ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613
+
+#NEED TO RENAME THE SNP ids 
+for f in $prefix.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.vcf.gz
+do
+i=$(echo $f| sed -e 's/.*\///' -e 's/.vcf.gz//')
+echo '#!/bin/bash' > $i.ids.sh
+echo "module load [bcftools 1.9 module]
+zcat $f | head -n 5000 | grep \"#\" > \$SLURM_TMPDIR/$i.header
+zcat $f | grep -v \"#\" | cut -f 1-5 | awk '{print \$1\"\t\"\$2\"\t\"\$1\":\"\$2\":\"\$4\":\"\$5\"\t\"\$4\"\t\"\$5}'> \$SLURM_TMPDIR/$i.5cols
+zcat $f | grep -v \"#\" | cut -f 6- > \$SLURM_TMPDIR/$i.lastCols
+paste \$SLURM_TMPDIR/$i.5cols \$SLURM_TMPDIR/$i.lastCols > \$SLURM_TMPDIR/$i.noHeader
+rm \$SLURM_TMPDIR/$i.5cols \$SLURM_TMPDIR/$i.lastCols
+cat \$SLURM_TMPDIR/$i.header \$SLURM_TMPDIR/$i.noHeader > $i.newIDs.vcf
+bgzip $i.newIDs.vcf
+tabix -p vcf $i.newIDs.vcf.gz
+rm \$SLURM_TMPDIR/$i.header \$SLURM_TMPDIR/$i.lastCols" >> $i.ids.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=20:00:00 --output=$i.ids.%j.out --error=$i.ids.%j.err --mem=40G --cpus-per-task=6 $i.ids.sh
+done
+
+
+
+
+cd ..
+mkdir common_1000G_HGDP
+cd common_1000G_HGDP
+
+#GET THE INTERSECT WITH 1000G + HGDP GRCh38 phase3 phased dataset
+ln -s [path to 1000G_HGDP] 1000G_HGDP_GRCh38
+
+
+
+plink --vcf ../ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.newIDs.vcf.gz --write-snplist --out UKB_ids.txt
+#do intersection
+
+
+for f in $(seq 1 22)
+do
+echo '#!/bin/bash' > $f.extractCommon.sh
+
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+plink --bfile 1000G_HGDP_GRCh38/gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc --extract UKB_ids.txt.snplist --make-bed --real-ref-alleles --out gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB 
+tabix -p vcf ALL.chr$f.shapeit2_integrated_snvindels_v2a_27022019.GRCh38.phased.onlySNPs.newIDs.commonUKB.vcf.gz" >> $f.extractCommon.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=5:00:00 --output=$f.extractCommon.%j.out --error=$f.extractCommon.%j.err --mem=40G --cpus-per-task=6 $f.extractCommon.sh
+done
+
+
+
+
+#Filters on 1000G
+
+for f in $(seq 1 22)
+do
+echo '#!/bin/bash' > $f.Maf0.05_pruning.sh
+prefix=gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB
+echo "module load [bcftools 1.9 module] [plink 1.9 module]
+plink --bfile $prefix --out $prefix.maf0.05 --make-bed --real-ref-alleles --maf 0.05
+plink --bfile $prefix.maf0.05 --indep-pairwise 50 5 0.5 --out $prefix.maf0.05.LDpruning
+plink --bfile $prefix.maf0.05 --extract $prefix.maf0.05.LDpruning.prune.in --real-ref-alleles --out $prefix.maf0.05.LDpruned --make-bed" >> $f.Maf0.05_pruning.sh
+sbatch --chdir $(pwd) --account=ctb-hussinju --time=1:00:00 --output=$f.Maf0.05_pruning.%j.out --error=$f.Maf0.05_pruning.%j.err --mem=40G --cpus-per-task=6 $f.Maf0.05_pruning.sh
+done
+
+#remove Low complexity and HLA
+#those files should be provided
+cp [path to lowcomplexity regions in GRCh38]/{HG38.Anderson2010.bed,HLA_region.bed} .
+cat HLA_region.bed HG38.Anderson2010.bed |sed 's/chr//' > lowComplexity_HLA.bed
+awk '{print $0"\tregion"NR}' lowComplexity_HLA.bed > lowComplexity_HLA.txt
+
+
+for f in $(seq 1 22) ; do echo "gnomad.genomes.v3.1.2.hgdp_tgp.chr$f.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB.maf0.05.LDpruned" >> allFiles.UKB.txt ; done
+
+plink --merge-list allFiles.UKB.txt --make-bed --real-ref-alleles --out gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB.maf0.05.LDpruned
+
+prefix=gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB
+plink --bfile $prefix.maf0.05.LDpruned --make-bed --real-ref-alleles --exclude range lowComplexity_HLA.txt --out $prefix.maf0.05.LDpruned.woLowComplexity_noHLA
+
+
+
+
+#Do last filters on UKB
+#one last check..
+
+grep -P "^-" ../ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.PLINK.fam > samplesToExcludeUKB.txt
+
+plink --vcf ../ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.newIDs.vcf.gz --remove samplesToExcludeUKB.txt --extract gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB.maf0.05.LDpruned.woLowComplexity_noHLA.bim --make-bed --real-ref-alleles --out ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.newIDs.common1000G_HGDP.noBadSamples.woLowComplexity_noHLA
+
+
+plink --bfile ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.newIDs.common1000G.noBadSamples --extract gnomad.genomes.v3.1.2.hgdp_tgp.PASSfiltered.newIDs.onlySNPs.noDuplicatePos.noMiss5perc.commonUKB.maf0.05.LDpruned.woLowComplexity_noHLA.bim --make-bed --real-ref-alleles --out ukb_v2.liftOverCommon.GRCh38.sorted.onlySNPs.woWithdrawn20240613.woSamePos.noDuplicatePos.QC.maxMiss0.5.fixref.onlyPolymorph.noBadPosTopMed.newIDs.common1000G_HGDP.noBadSamples.woLowComplexity_noHLA


### PR DESCRIPTION
From JC: 

- `1000G_HGDP_processing_general.sh` and `1000G_HGDP_filters_general.sh` process the 1000G+HGDP dataset. 
- The first one is basically doing all the QC and MAF filters. 
- The second one is the one with which you can play with to change the LD pruning parameters. I left the original thresholds I was using, but parameters can be changed in there so you have different number of SNPs in the end.

`UKB_liftover_allcohort_general.sh` does the conversion of positions from hg19 to GRCh38 for the UKBiobank dataset.

`UKB_preprocessing_general.sh` and `MHI_Cartagene_preprocessing_general.sh` are the ones where I'm doing the allele matching to the genome reference for the datasets, then do different QC and MAF filters and finally do the intersection with the 1000G+HGDP dataset. I end up doing a LD pruning and removing the HLA and low complexity regions.

Can add JC as reviewer here so he can comment/edit as needed.