### PR TITLE
Adds `get_sampe_ids` method to hgdp, aou and ukbb datasets

### DIFF
--- a/manylatents/data/aou_dataset.py
+++ b/manylatents/data/aou_dataset.py
@@ -152,6 +152,12 @@ class AOUDataset(PlinkDataset, PrecomputedMixin):
             raise ValueError(f"Label column '{label_col}' not found in metadata.")
 
         return self.metadata[label_col].values
+
+    def get_sample_ids(self) -> np.ndarray:
+        """
+        Returns sample IDs for the dataset.
+        """
+        return self.metadata.index.values
     
     def balance_filter(self, balance_filter) -> np.array:
 

--- a/manylatents/data/hgdp_dataset.py
+++ b/manylatents/data/hgdp_dataset.py
@@ -167,15 +167,22 @@ class HGDPDataset(PlinkDataset, PrecomputedMixin):
         """
         if label_col not in self.metadata.columns:
             raise ValueError(f"Label column '{label_col}' not found in metadata.")
-        
+
         return self.metadata[label_col].values
+
+    def get_sample_ids(self) -> np.ndarray:
+        """
+        Returns sample IDs for the dataset.
+        """
+        return self.metadata['sample_id'].values
     
-    def extract_indices(self, 
+    def extract_indices(self,
                         filter_qc: bool,
                         filter_related: bool,
                         test_all: bool,
                         remove_recent_migration: bool,
-                        balance_filter: bool
+                        balance_filter: bool,
+                        subsample_n: Optional[int] = None
                        ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Extracts fit/transform indices based on metadata filters.
@@ -184,8 +191,9 @@ class HGDPDataset(PlinkDataset, PrecomputedMixin):
             filter_related (Optional[bool]): Whether to filter related samples.
             test_all (Optional[bool]): Whether to use all samples for testing.
             remove_recent_migration (Optional[bool]): remove recently migrated samples.
+            subsample_n (Optional[int]): If specified, randomly subsample to this many samples after other filters.
         """
-        fit_idx, trans_idx = super().extract_indices(filter_qc, filter_related, test_all, remove_recent_migration, balance_filter)
+        fit_idx, trans_idx = super().extract_indices(filter_qc, filter_related, test_all, remove_recent_migration, balance_filter, subsample_n)
 
         # First entry is dummy row. So we ignore this!
         fit_idx[0] = False

--- a/manylatents/data/plink_dataset.py
+++ b/manylatents/data/plink_dataset.py
@@ -317,12 +317,22 @@ class PlinkDataset(Dataset):
     def get_labels(self, label_col: str = "Population") -> np.ndarray:
         """
         Abstract method that should return an array of labels for the dataset.
-        
+
         Args:
             label_col (str): Name of the column to use as labels.
-        
+
         Returns:
             np.ndarray: Array of labels.
+        """
+        pass
+
+    @abstractmethod
+    def get_sample_ids(self) -> np.ndarray:
+        """
+        Abstract method that should return an array of sample IDs for the dataset.
+
+        Returns:
+            np.ndarray: Array of sample IDs.
         """
         pass
     

--- a/manylatents/data/ukbb_dataset.py
+++ b/manylatents/data/ukbb_dataset.py
@@ -159,6 +159,12 @@ class UKBBDataset(PlinkDataset, PrecomputedMixin):
 
         return self.metadata[label_col].values
 
+    def get_sample_ids(self) -> np.ndarray:
+        """
+        Returns sample IDs for the dataset.
+        """
+        return self.metadata['sample_id'].values
+
     def balance_filter(self, balance_filter) -> np.array:
 
         num_dominant = self.metadata[(self.metadata['Population'] == 'EUR')].shape[0]

--- a/manylatents/metrics/sample_id.py
+++ b/manylatents/metrics/sample_id.py
@@ -12,8 +12,9 @@ def sample_id(embeddings: np.ndarray,
     Fetches sample IDs (for downstream analysis)
     """
 
-    if hasattr(dataset, 'metadata') and 'sample_id' in dataset.metadata:
-        sample_ids = dataset.metadata['sample_id']
-        return sample_ids
+    if hasattr(dataset, 'get_sample_ids'):
+        return dataset.get_sample_ids()
     else:
-        return None
+        # Return array of indices as sample IDs when not available
+        logger.warning("Sample IDs not found in dataset (no get_sample_ids method). Using numeric indices instead.")
+        return np.arange(len(embeddings))


### PR DESCRIPTION
Adds `get_sample_ids` method to hgdp, aou and ukbb datasets.
This is used by sample_id metric. If method does not exist, just returns numeric index.