### PR TITLE
Fix: Enable namespace package support in manylatents

### DIFF
--- a/manylatents/__init__.py
+++ b/manylatents/__init__.py
@@ -1,0 +1,2 @@
+# Namespace package - this allows extensions like manylatents.omics to extend manylatents
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Summary

  Adds namespace package declaration to manylatents/__init__.py to properly support extensions like manylatents-omics.

  Problem

  Without namespace package configuration, Python's import system cannot merge multiple packages under the same manylatents namespace. This
  caused:
 ` import manylatents.omics  # ModuleNotFoundError`

  Even though manylatents-omics was installed, Python only recognized the core manylatents package path and ignored the extension.

  Solution

  Declared manylatents as a namespace package using pkgutil.extend_path():

```
  # manylatents/__init__.py
  # Namespace package - this allows extensions like manylatents.omics to extend manylatents
  __path__ = __import__('pkgutil').extend_path(__path__, __name__)
```

  This enables Python to discover and merge all manylatents subpackages across multiple installation locations.

  Verification

```
import manylatents
  print(manylatents.__path__)
  # Before: ['/path/to/manylatents/manylatents']
  # After:  ['/path/to/manylatents/manylatents', '/path/to/manylatents-omics/manylatents']


  import manylatents.omics  # ✓ Now works
```