### PR TITLE
Fix: Correct nested config access for embedding callbacks

### DIFF
--- a/manylatents/experiment.py
+++ b/manylatents/experiment.py
@@ -317,7 +317,7 @@ def run_algorithm(cfg: DictConfig, input_data_holder: Optional[Dict] = None) -> 
 
     # --- Callbacks ---
     trainer_cb_cfg   = cfg.trainer.get("callbacks")
-    embedding_cb_cfg = cfg.get("callbacks.embedding")
+    embedding_cb_cfg = cfg.callbacks.get("embedding") if hasattr(cfg, "callbacks") else None
 
     lightning_cbs, embedding_cbs = instantiate_callbacks(
         trainer_cb_cfg,


### PR DESCRIPTION
Problem

  Embedding callbacks (SaveEmbeddings, PlotEmbeddings, WandbLogScores) were never being instantiated or executed, even when properly
  configured in experiment configs. This resulted in:
  - No embedding CSV files saved
  - No embedding PNG plots generated
  - No WandB logging of embeddings

  Root Cause

  Line 320 in experiment.py was using incorrect syntax to access nested DictConfig:

` embedding_cb_cfg = cfg.get("callbacks.embedding")  # Always returns None`

  The .get() method with dot notation doesn't traverse nested OmegaConf DictConfigs, so this always returned None regardless of the actual
  config content.

  Fix

  Changed to use attribute access followed by .get(), consistent with the pattern used elsewhere in the file (e.g., lines 137, 311-312):

` embedding_cb_cfg = cfg.callbacks.get("embedding") if hasattr(cfg, "callbacks") else None`

  This properly accesses the nested callbacks.embedding config and allows callbacks to be instantiated.

  Impact

  - Before: embedding_cb_cfg = None → 0 callbacks instantiated → no outputs saved
  - After: embedding_cb_cfg = {save_embeddings: {...}, plot_embeddings: {...}, wandb_log_scores: {...}} → 3 callbacks instantiated →
  embeddings saved as expected