### PR TITLE
Refactor: Integrate SaveMetricTables functionality into SaveEmbeddings

### DIFF
--- a/manylatents/callbacks/embedding/save_embeddings.py
+++ b/manylatents/callbacks/embedding/save_embeddings.py
@@ -18,27 +18,27 @@ class SaveEmbeddings(EmbeddingCallback):
                  save_dir: str = "outputs",
                  save_format: str = "npy",
                  experiment_name: str = "experiment",
-                 include_metrics: bool = False,
                  use_timestamp: bool = True,
-                 save_additional_outputs: bool = False) -> None:
+                 save_additional_outputs: bool = False,
+                 save_metric_tables: bool = False) -> None:
         """
-        SaveEmbeddings callback that saves EmbeddingOutputs.
+        SaveEmbeddings callback that saves EmbeddingOutputs and optionally metric tables.
 
         Args:
             save_dir: Base directory for saving outputs (Hydra will create subdirs)
             save_format: Format for main embeddings ("csv", "npy", etc.)
             experiment_name: Name for file naming
-            include_metrics: Whether to include scores/metrics in CSV format
             use_timestamp: Whether to include timestamp in names
             save_additional_outputs: Whether to save non-embeddings keys as separate files
+            save_metric_tables: Whether to save separate metric table CSVs (scalar, per-sample)
         """
         super().__init__()
         self.save_dir        = save_dir
         self.save_format     = save_format
         self.experiment_name = experiment_name
-        self.include_metrics = include_metrics
         self.use_timestamp   = use_timestamp
         self.save_additional_outputs = save_additional_outputs
+        self.save_metric_tables = save_metric_tables
         os.makedirs(self.save_dir, exist_ok=True)
         logger.info(f"SaveEmbeddings initialized with directory: {self.save_dir} and format: {self.save_format}")
 
@@ -86,19 +86,8 @@ class SaveEmbeddings(EmbeddingCallback):
             self._save_single_file(embeddings, X)
 
     def _save_csv(self, embeddings: dict, X: np.ndarray) -> None:
-        """Save as CSV with optional additional columns."""
+        """Save embeddings as CSV."""
         df = pd.DataFrame(X, columns=[f"dim_{i+1}" for i in range(X.shape[1])])
-
-        if self.include_metrics:
-            for key, value in embeddings.items():
-                if key == "embeddings":
-                    continue
-                value = self._to_numpy(value)
-                if isinstance(value, np.ndarray) and value.ndim == 1 and len(value) == len(df):
-                    df[key] = value
-                elif isinstance(value, (list, tuple)) and len(value) == len(df):
-                    df[key] = value
-
         df.to_csv(self.save_path, index=False)
 
     def _save_single_file(self, embeddings: dict, X: np.ndarray) -> None:
@@ -128,9 +117,153 @@ class SaveEmbeddings(EmbeddingCallback):
                     json.dump(value, f, indent=2, default=str)
                 logger.info(f"Saved {key} to {path}")
 
+    def _unpack_tuple_scores(self, raw_scores: dict) -> dict:
+        """
+        Unpack (scalar, per_sample_array) tuples into separate entries.
+        Some metrics return both a scalar summary and per-sample values as a tuple.
+        """
+        scores = {}
+        for name, vals in raw_scores.items():
+            if isinstance(vals, tuple) and len(vals) == 2:
+                scalar, arr = vals
+                scores[name] = float(scalar)
+                scores[f"{name}__per_sample"] = np.asarray(arr)
+            else:
+                scores[name] = vals
+        return scores
+
+    def _determine_n_samples(self, dataset, embeddings: dict) -> int:
+        """Determine the number of samples from dataset or embeddings."""
+        try:
+            return len(dataset)
+        except:
+            # Fallback to embeddings shape
+            emb = embeddings.get("embeddings")
+            if emb is not None:
+                emb_np = emb.numpy() if hasattr(emb, "numpy") else emb
+                return emb_np.shape[0]
+            return None
+
+    def _flatten_scalar_metrics(self, scores: dict, n_samples: int) -> dict:
+        """
+        Flatten non-per-sample metrics into scalars.
+
+        Returns only metrics where arr.shape[0] != n_samples (i.e., not per-sample).
+        Multi-valued arrays are flattened with suffixes.
+        """
+        flattened = {}
+        for name, value in scores.items():
+            arr = np.asarray(value)
+
+            if arr.ndim == 0:
+                # Scalar
+                flattened[name] = float(value)
+            elif arr.shape[0] != n_samples:
+                # Not per-sample: flatten array with suffixes
+                if arr.ndim == 1:
+                    for i, val in enumerate(arr, start=1):
+                        flattened[f"{name}_{i}"] = float(val)
+                else:
+                    # Multi-dimensional: flatten all dimensions
+                    flat_arr = arr.flatten()
+                    for i, val in enumerate(flat_arr, start=1):
+                        flattened[f"{name}_{i}"] = float(val)
+        return flattened
+
+    def _flatten_per_sample_metrics(self, scores: dict, n_samples: int) -> dict:
+        """
+        Flatten per-sample metrics (where arr.shape[0] == n_samples).
+
+        Multi-dimensional per-sample arrays (e.g., n_samples × k) are flattened
+        along non-sample dimensions with suffixes.
+        """
+        flattened = {}
+        for name, value in scores.items():
+            arr = np.asarray(value)
+
+            if arr.ndim >= 1 and arr.shape[0] == n_samples:
+                # Per-sample metric
+                if arr.ndim == 1:
+                    # Simple 1-D array (e.g., sample_id)
+                    flattened[name] = arr
+                else:
+                    # Multi-dimensional (e.g., n_samples × k)
+                    # Flatten along non-sample dimensions
+                    if arr.ndim == 2:
+                        for i in range(arr.shape[1]):
+                            flattened[f"{name}_{i+1}"] = arr[:, i]
+                    else:
+                        # Higher dimensions: flatten to 2D then split
+                        reshaped = arr.reshape(n_samples, -1)
+                        for i in range(reshaped.shape[1]):
+                            flattened[f"{name}_{i+1}"] = reshaped[:, i]
+        return flattened
+
+    def _save_scalar_metrics(self, scores: dict, timestamp: str) -> str:
+        """Save all scalar metrics to a single-row CSV."""
+        if not scores:
+            logger.info("No scalar metrics to save.")
+            return None
+
+        filename = f"metrics_summary_{self.experiment_name}_{timestamp}.csv"
+        save_path = os.path.join(self.save_dir, filename)
+
+        df = pd.DataFrame([scores])
+        df.to_csv(save_path, index=False)
+
+        logger.info(f"Saved {len(scores)} scalar metrics to {save_path}")
+        return save_path
+
+    def _save_per_sample_metrics(self, scores: dict, timestamp: str) -> str:
+        """Save all per-sample metrics to a CSV table (n_samples × n_metrics)."""
+        if not scores:
+            logger.info("No per-sample metrics to save.")
+            return None
+
+        filename = f"metrics_per_sample_{self.experiment_name}_{timestamp}.csv"
+        save_path = os.path.join(self.save_dir, filename)
+
+        df = pd.DataFrame(scores)
+        df.to_csv(save_path, index=False)
+
+        logger.info(
+            f"Saved {len(scores)} per-sample metric columns with {len(df)} rows to {save_path}"
+        )
+        return save_path
+
     def on_latent_end(self, dataset: any, embeddings: dict) -> str:
         self.save_embeddings(embeddings)
         self.register_output("saved_embeddings", self.save_path)
+
+        # Optionally save metric tables
+        if self.save_metric_tables:
+            raw_scores = embeddings.get("scores", {})
+            if raw_scores:
+                # Unpack tuple scores
+                scores = self._unpack_tuple_scores(raw_scores)
+
+                # Determine number of samples
+                n_samples = self._determine_n_samples(dataset, embeddings)
+
+                if n_samples is not None:
+                    # Generate timestamp for consistent naming
+                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+                    # Flatten and save scalar metrics
+                    scalar_metrics = self._flatten_scalar_metrics(scores, n_samples)
+                    scalar_path = self._save_scalar_metrics(scalar_metrics, timestamp)
+                    if scalar_path:
+                        self.register_output("scalar_metrics_path", scalar_path)
+
+                    # Flatten and save per-sample metrics
+                    per_sample_metrics = self._flatten_per_sample_metrics(scores, n_samples)
+                    per_sample_path = self._save_per_sample_metrics(per_sample_metrics, timestamp)
+                    if per_sample_path:
+                        self.register_output("per_sample_metrics_path", per_sample_path)
+                else:
+                    logger.warning("Could not determine number of samples. Skipping metric table save.")
+            else:
+                logger.warning("No scores found in embeddings. Skipping metric table save.")
 
         run = wandb.run
         if run is not None:

--- a/manylatents/configs/callbacks/embedding/save_embeddings.yaml
+++ b/manylatents/configs/callbacks/embedding/save_embeddings.yaml
@@ -3,4 +3,4 @@ save_embeddings:
   save_dir: ${hydra:runtime.output_dir}
   save_format: "csv"
   experiment_name: ${name}
-  include_metrics: false
+  save_metric_tables: false


### PR DESCRIPTION
Replaces #151
 
Consolidated metric table saving functionality into the SaveEmbeddings callback, eliminating the need for a separate SaveMetricTables callback.
This refactor follows the Single Responsibility Principle while introducing flexible output formats for metric tables.

⸻

🔧 Changes

1. Enhanced SaveEmbeddings Callback

File: tools/manylatents/manylatents/callbacks/embedding/save_embeddings.py
	•	Added
	•	save_metric_tables: bool = False → enables saving metrics to separate CSV files
	•	Removed
	•	include_metrics (deprecated; previously mixed embeddings and metrics in a single CSV)

New methods:
	•	_unpack_tuple_scores() → Unpacks (scalar, per_sample_array) tuples returned by some metrics
	•	_determine_n_samples() → Determines number of samples from dataset or embeddings
	•	_flatten_scalar_metrics() → Flattens scalar or small-array metrics (e.g., connected_components_1, connected_components_2)
	•	_flatten_per_sample_metrics() → Flattens per-sample metrics (e.g., n_samples × k → k columns with suffixes)
	•	_save_scalar_metrics() → Saves scalar metrics to single-row CSV (metrics_summary_*.csv)
	•	_save_per_sample_metrics() → Saves per-sample metrics to table CSV (metrics_per_sample_*.csv)

Modified:
	•	on_latent_end() → Conditionally saves metric tables when save_metric_tables=True

⸻

2. Metric Organization Strategy

The refactor standardizes handling for three metric types:
	1.	Scalar metrics (0-D):
Single values (e.g., gt_preservation, trustworthiness)
→ Saved to metrics_summary_*.csv (1 row)
	2.	Multi-valued non-per-sample arrays:
Arrays where len(arr) != n_samples (e.g., connected_components, affinity_spectrum)
→ Flattened with suffixes (connected_components_1, connected_components_2, …)
→ Saved to metrics_summary_*.csv (same as scalars)
	3.	Per-sample metrics:
Arrays where arr.shape[0] == n_samples (e.g., sample_id)
→ Multi-dimensional arrays (n_samples × k) flattened to k columns
→ Saved to metrics_per_sample_*.csv (one row per sample)
	4.	Non-tabular outputs:
Still handled by save_additional_outputs (e.g., graphs, images, etc.)

⸻

3. Config Updates

configs/manylatents/callbacks/embedding/save_embeddings.yaml
	•	Removed: include_metrics: false
	•	Added: save_metric_tables: true

tools/manylatents/manylatents/configs/callbacks/embedding/save_embeddings.yaml
	•	Removed: include_metrics: false
	•	Added: save_metric_tables: false (default in tool)

configs/manylatents/experiment/synthetic/synthetic_sweep_phate.yaml
	•	Added explicit override:
callbacks.embedding.save_embeddings.save_metric_tables: true

⸻

✅ Benefits
	1.	Unified callback for embeddings and metrics
	2.	Flexible output format (separate CSVs for scalar vs per-sample metrics)
	3.	Handles multi-dimensional metrics with intelligent flattening/suffixing
	4.	Backward compatible (save_metric_tables=False by default)
	5.	Clean separation — removes deprecated include_metrics flag

⸻

📦 Example Output

For an experiment with 2000 samples:
```
outputs/2025-10-31/17-21-05/experiment_name/
├── embeddings_*.csv              # 2000 × 2 (dim_1, dim_2)
├── metrics_summary_*.csv         # 1 × N (gt_preservation, connected_components_1, ...)
├── metrics_per_sample_*.csv      # 2000 × M (sample_id, per_sample_metric_1, ...)
└── embedding_plot_*.png
```

Files changed:
	•	tools/manylatents/manylatents/callbacks/embedding/save_embeddings.py
	•	tools/manylatents/manylatents/configs/callbacks/embedding/save_embeddings.yaml