### PR TITLE
removed unneeded args for dla_tree and eb

### DIFF
--- a/manylatents/data/dlatree.py
+++ b/manylatents/data/dlatree.py
@@ -24,8 +24,6 @@ class DLATreeDataModule(LightningDataModule):
         n_dim: int = 3,
         disconnect_branches: Optional[List[int]] = [5,15],
         sampling_density_factors: Optional[Dict[int, float]] = None,
-        precomputed_path: str = None,
-        mmap_mode: str = None,
         mode: str = 'full',
     ):
         """
@@ -69,13 +67,6 @@ class DLATreeDataModule(LightningDataModule):
 
         sampling_density_factors : dict of int to float or None, optional
             Dictionary mapping branch index to sampling reduction factor (e.g., 0.5 keeps 50% of points).
-        
-        precomputed_path : str, optional
-            Path to precomputed embeddings. If provided, the embeddings will be loaded from this path.
-            If None, a new dataset will be generated.
-        
-        mmap_mode : str, optional
-            Memory mapping mode for loading the dataset. If None, the dataset will be loaded into memory.
 
         mode : str, default='full'
             Mode for dataset train/test seperation. 
@@ -102,8 +93,6 @@ class DLATreeDataModule(LightningDataModule):
         self.sampling_density_factors = sampling_density_factors
 
         self.mode = mode
-        self.precomputed_path = precomputed_path
-        self.mmap_mode = mmap_mode
 
         self.dataset = None
         self.train_dataset = None
@@ -125,8 +114,6 @@ class DLATreeDataModule(LightningDataModule):
                 sigma=self.sigma,
                 disconnect_branches=self.disconnect_branches,
                 sampling_density_factors=self.sampling_density_factors,
-                precomputed_path=self.precomputed_path,
-                mmap_mode=self.mmap_mode,
             )
             self.test_dataset = self.train_dataset
 
@@ -141,8 +128,6 @@ class DLATreeDataModule(LightningDataModule):
                 sigma=self.sigma,
                 disconnect_branches=self.disconnect_branches,
                 sampling_density_factors=self.sampling_density_factors,
-                precomputed_path=self.precomputed_path,
-                mmap_mode=self.mmap_mode,
             )
 
             test_size = int(len(self.dataset) * self.test_split)
@@ -194,8 +179,6 @@ class DLATreeFromGraphDataModule(LightningDataModule):
         sigma: float = 0.5,
         save_graph_viz: bool = True,
         save_dir: str = "outputs",
-        precomputed_path: str = None,
-        mmap_mode: str = None,
         mode: str = 'full',
         **kwargs
     ):
@@ -220,8 +203,6 @@ class DLATreeFromGraphDataModule(LightningDataModule):
         self.save_dir = save_dir
 
         self.mode = mode
-        self.precomputed_path = precomputed_path
-        self.mmap_mode = mmap_mode
 
         self.dataset = None
         self.train_dataset = None
@@ -242,8 +223,6 @@ class DLATreeFromGraphDataModule(LightningDataModule):
                 sigma=self.sigma,
                 save_graph_viz=self.save_graph_viz,
                 save_dir=self.save_dir,
-                precomputed_path=self.precomputed_path,
-                mmap_mode=self.mmap_mode,
             )
             self.test_dataset = self.train_dataset
 
@@ -257,8 +236,6 @@ class DLATreeFromGraphDataModule(LightningDataModule):
                 sigma=self.sigma,
                 save_graph_viz=self.save_graph_viz,
                 save_dir=self.save_dir,
-                precomputed_path=self.precomputed_path,
-                mmap_mode=self.mmap_mode,
             )
 
             test_size = int(len(self.dataset) * self.test_split)

--- a/manylatents/data/embryoidbody.py
+++ b/manylatents/data/embryoidbody.py
@@ -16,8 +16,6 @@ class EmbryoidBodyDataModule(LightningDataModule):
         random_state: int = 42,
         adata_path: str = None,
         label_key: str = None,
-        precomputed_path: str = None,
-        mmap_mode: str = None,
         mode: str = 'full',
     ):
         """
@@ -41,9 +39,6 @@ class EmbryoidBodyDataModule(LightningDataModule):
         label_key : str, default="cell_type"
             Key in adata.obs used to retrieve cell type or condition labels.
 
-        precomputed_path : str or None, optional
-            Optional path to a precomputed .h5ad file. If provided and exists, this file is used instead of adata_path.
-
         mode : str, default='full'
             Mode for dataset train/test seperation. 
             If 'full', the entire dataset is used as both training and test set (unsplit).
@@ -60,8 +55,6 @@ class EmbryoidBodyDataModule(LightningDataModule):
         # EmbryoidBody specific parameters
         self.adata_path = adata_path
         self.label_key = label_key
-        self.precomputed_path = precomputed_path
-        self.mmap_mode = mmap_mode
 
         self.mode = mode
 
@@ -75,15 +68,13 @@ class EmbryoidBodyDataModule(LightningDataModule):
 
     def setup(self, stage: str = None):
         if self.mode == "full":
-            self.train_dataset = EmbryoidBody(adata_path=self.adata_path, 
-                                              label_key=self.label_key, 
-                                              precomputed_path=self.precomputed_path)
+            self.train_dataset = EmbryoidBody(adata_path=self.adata_path,
+                                              label_key=self.label_key)
             self.test_dataset = self.train_dataset
 
         elif self.mode == 'split':
-            self.dataset = EmbryoidBody(adata_path=self.adata_path, 
-                                        label_key=self.label_key, 
-                                        precomputed_path=self.precomputed_path)
+            self.dataset = EmbryoidBody(adata_path=self.adata_path,
+                                        label_key=self.label_key)
             test_size = int(len(self.dataset) * self.test_split)
             train_size = len(self.dataset) - test_size
 
@@ -124,8 +115,6 @@ if __name__ == "__main__":
     EB = EmbryoidBodyDataModule(
         adata_path="./data/scRNAseq/EBT_counts.h5ad",
         label_key="sample_labels",
-        precomputed_path=None,
-        mmap_mode=None,
         batch_size=32,
         test_split=0.2,
         num_workers=4,


### PR DESCRIPTION
# PR: Remove Deprecated PrecomputedMixin Parameters from DataModules

## Summary
This PR removes unused `precomputed_path` and `mmap_mode` parameters from synthetic and single-cell dataset DataModules following the deprecation of `PrecomputedMixin`. These parameters were causing `TypeError` exceptions when instantiating datasets.

## Problem

After the deprecation of `PrecomputedMixin` (see comment in `synthetic_dataset.py` lines 12-15), the underlying Dataset classes (DLAtree, DLATreeFromGraph, EmbryoidBody) no longer accept `precomputed_path` and `mmap_mode` parameters. However, the DataModule classes still accepted these parameters and attempted to pass them to Dataset constructors, causing runtime errors:

```python
TypeError: DLATreeFromGraph.__init__() got an unexpected keyword argument 'precomputed_path'
```

### Why PrecomputedMixin Was Deprecated

From `synthetic_dataset.py`:
> PrecomputedMixin was originally intended to load pre-generated synthetic data,
> but synthetic datasets are fast to generate on-the-fly. For loading saved
> embeddings/outputs from previous runs, use PrecomputedDataModule instead.

## Changes

### Modified Files

#### DataModule Classes (Python)
1. **`manylatents/data/dlatree.py`**
   - `DLATreeDataModule.__init__()`: Removed `precomputed_path` and `mmap_mode` parameters
   - `DLATreeDataModule.setup()`: Removed these parameters from DLAtree instantiation calls
   - `DLATreeFromGraphDataModule.__init__()`: Removed `precomputed_path` and `mmap_mode` parameters
   - `DLATreeFromGraphDataModule.setup()`: Removed these parameters from DLATreeFromGraph instantiation calls
   - Updated docstrings to remove parameter documentation
   - Fixed example code in `__main__` block to remove these parameters

2. **`manylatents/data/embryoidbody.py`**
   - `EmbryoidBodyDataModule.__init__()`: Removed `precomputed_path` and `mmap_mode` parameters
   - `EmbryoidBodyDataModule.setup()`: Removed these parameters from EmbryoidBody instantiation calls
   - Updated docstrings to remove parameter documentation
   - Updated example usage code at bottom of file

#### Dataset Classes (Python)
3. **`manylatents/data/singlecell_dataset.py`**
   - `EmbryoidBody.__init__()`: Removed `precomputed_path` and `mmap_mode` parameters
   - `EmbryoidBody` now only passes `adata_path` and `label_key` to parent `SinglecellDataset`
   - Updated docstring to remove parameter documentation
   - **Note**: This is the Dataset class, not the DataModule. The parent `SinglecellDataset` never accepted these parameters, so passing them was causing TypeError