### PR TITLE
feat(algorithms): Add MultiscalePHATEModule for hierarchical embedding

### DIFF
--- a/manylatents/algorithms/latent/__init__.py
+++ b/manylatents/algorithms/latent/__init__.py
@@ -3,14 +3,16 @@ from .pca import PCAModule
 from .tsne import TSNEModule
 from .umap import UMAPModule
 from .phate import PHATEModule
+from .multiscale_phate import MultiscalePHATEModule
 from .diffusion_map import DiffusionMapModule
 from .multi_dimensional_scaling import MDSModule
 
 __all__ = [
     "PCAModule",
-    "TSNEModule", 
+    "TSNEModule",
     "UMAPModule",
     "PHATEModule",
+    "MultiscalePHATEModule",
     "DiffusionMapModule",
     "MDSModule",
 ]

--- a/manylatents/algorithms/latent/multiscale_phate.py
+++ b/manylatents/algorithms/latent/multiscale_phate.py
@@ -1,0 +1,210 @@
+"""
+Multiscale PHATE dimensionality reduction with diffusion condensation.
+
+This module wraps the multiscale_phate library to provide hierarchical
+embedding with stable component detection across scales.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+import torch
+from multiscale_phate import Multiscale_PHATE
+from torch import Tensor
+
+from .latent_module_base import LatentModule
+
+
+class MultiscalePHATEModule(LatentModule):
+    """
+    Multiscale PHATE for hierarchical dimensionality reduction.
+
+    Uses diffusion condensation to identify stable resolutions and compute
+    embeddings at multiple scales. Useful for detecting the number of
+    connected components (β₀) that are stable across coarsening.
+
+    Parameters
+    ----------
+    n_components : int, default=2
+        Number of dimensions for the final embedding.
+    scale : float, default=1.025
+        Epsilon growth rate for condensation. Higher = faster coarsening.
+    granularity : float, default=0.1
+        Merge threshold sensitivity. Lower = more aggressive merging.
+    landmarks : int, default=2000
+        Number of landmarks for scalability.
+    knn : int, default=5
+        Number of nearest neighbors for graph construction.
+    decay : int, default=40
+        Kernel tail decay rate.
+    gamma : float, default=1
+        Informational distance constant.
+    n_pca : int, optional
+        Number of PCA components for preprocessing. None = auto.
+    n_jobs : int, default=1
+        Number of parallel jobs.
+    random_state : int, optional, default=42
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        n_components: int = 2,
+        scale: float = 1.025,
+        granularity: float = 0.1,
+        landmarks: int = 2000,
+        knn: int = 5,
+        decay: int = 40,
+        gamma: float = 1.0,
+        n_pca: Optional[int] = None,
+        n_jobs: int = 1,
+        random_state: Optional[int] = 42,
+        **kwargs,
+    ):
+        super().__init__(n_components=n_components, init_seed=random_state, **kwargs)
+
+        self.scale = scale
+        self.granularity = granularity
+        self.landmarks = landmarks
+        self.knn = knn
+        self.decay = decay
+        self.gamma = gamma
+        self.n_pca = n_pca
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+
+        self.model = Multiscale_PHATE(
+            scale=scale,
+            granularity=granularity,
+            landmarks=landmarks,
+            knn=knn,
+            decay=decay,
+            gamma=gamma,
+            n_pca=n_pca,
+            n_jobs=n_jobs,
+            random_state=random_state,
+        )
+
+        # Store results after fitting
+        self.embedding_: Optional[np.ndarray] = None
+        self.clusters_: Optional[np.ndarray] = None
+        self.sizes_: Optional[np.ndarray] = None
+
+    def fit(self, x: Tensor) -> None:
+        """
+        Fit Multiscale PHATE and compute embedding at finest resolution.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input data of shape (n_samples, n_features).
+        """
+        x_np = x.detach().cpu().numpy()
+        self.embedding_, self.clusters_, self.sizes_ = self.model.fit_transform(x_np)
+        self._is_fitted = True
+
+    def transform(self, x: Tensor) -> Tensor:
+        """
+        Return the embedding at finest resolution.
+
+        Note: Multiscale PHATE computes the embedding during fit.
+        This method returns the precomputed embedding. The returned
+        embedding may have fewer points than the input due to merging.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input data (used only for device/dtype information).
+
+        Returns
+        -------
+        Tensor
+            2D embedding of shape (n_aggregated_points, n_components).
+        """
+        if not self._is_fitted:
+            raise RuntimeError(
+                "Multiscale PHATE model is not fitted yet. Call `fit` first."
+            )
+        return torch.tensor(self.embedding_, device=x.device, dtype=x.dtype)
+
+    def get_n_components_per_scale(self) -> np.ndarray:
+        """
+        Get number of connected components (β₀) at each condensation scale.
+
+        Returns
+        -------
+        np.ndarray
+            Array of component counts, one per scale. Monotonically non-increasing.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call `fit` first.")
+        return np.array([len(np.unique(c)) for c in self.model.NxTs])
+
+    def get_gradient(self) -> np.ndarray:
+        """
+        Get gradient profile across scales.
+
+        Low gradient indicates stable resolutions where component count
+        doesn't change rapidly.
+
+        Returns
+        -------
+        np.ndarray
+            Gradient values at each scale transition.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call `fit` first.")
+        return self.model.gradient
+
+    def get_stable_scales(self) -> List[int]:
+        """
+        Get indices of stable (salient) resolutions.
+
+        These are scales where the gradient is low, indicating stable
+        component structure.
+
+        Returns
+        -------
+        List[int]
+            Indices into the scale array for stable resolutions.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call `fit` first.")
+        return list(self.model.levels)
+
+    def get_cluster_assignments(self, scale_idx: int = 0) -> np.ndarray:
+        """
+        Get cluster assignments at a specific scale.
+
+        Parameters
+        ----------
+        scale_idx : int, default=0
+            Index into NxTs. 0 = finest (most clusters), -1 = coarsest.
+
+        Returns
+        -------
+        np.ndarray
+            Cluster labels for each original data point.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call `fit` first.")
+        return self.model.NxTs[scale_idx]
+
+    def get_n_stable_components(self) -> int:
+        """
+        Get number of components at the most stable resolution.
+
+        Convenience method that returns β₀ at the first stable scale.
+
+        Returns
+        -------
+        int
+            Number of stable connected components.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Model not fitted. Call `fit` first.")
+        stable_scales = self.get_stable_scales()
+        if not stable_scales:
+            # Fallback to coarsest scale
+            return len(np.unique(self.model.NxTs[-1]))
+        return len(np.unique(self.model.NxTs[stable_scales[0]]))

--- a/manylatents/configs/algorithms/latent/multiscale_phate.yaml
+++ b/manylatents/configs/algorithms/latent/multiscale_phate.yaml
@@ -1,0 +1,11 @@
+_target_: manylatents.algorithms.latent.multiscale_phate.MultiscalePHATEModule
+n_components: 2
+scale: 1.025
+granularity: 0.1
+landmarks: 2000
+knn: 5
+decay: 40
+gamma: 1.0
+n_pca: null
+n_jobs: 1
+random_state: ${seed}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
     "hydra-submitit-launcher>=1.2.0",
     "scanpy>=1.10.3",
     "pyproj>=3.6.1",
+    "multiscale-phate>=0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1407,6 +1407,7 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "multiscale-phate" },
     { name = "nest-asyncio" },
     { name = "numpy" },
     { name = "opentsne" },
@@ -1499,6 +1500,7 @@ requires-dist = [
     { name = "matplotlib-inline", specifier = "==0.1.6" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.12" },
+    { name = "multiscale-phate", specifier = ">=0.0" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "numpy", specifier = ">=1.25" },
     { name = "opentsne", specifier = ">=1.0.2" },
@@ -1867,6 +1869,25 @@ wheels = [
 ]
 
 [[package]]
+name = "multiscale-phate"
+version = "0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphtools" },
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "phate" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy" },
+    { name = "tasklogger" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/9f6a47268209197fad84c125802942d77b608bad0c8df4864ddeec484e5f/multiscale_phate-0.0.tar.gz", hash = "sha256:09a32aa483768ec235679146adeb6c5ca3d4de43b69001a4349847a503813cc0", size = 27066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/5e/cf74348a31d5da281477a730b99e9e8b4622c1786a7108f28c9c1fec3f1d/multiscale_phate-0.0-py3-none-any.whl", hash = "sha256:3cb46ef9df4061b1dc6d3908ef7149ca209fd3f2cf475ebfb93cfd084e3faed2", size = 28627 },
+]
+
+[[package]]
 name = "natsort"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2009,7 +2030,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878 },
@@ -2021,7 +2042,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211 },
@@ -2051,9 +2072,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841 },
@@ -2065,7 +2086,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129 },


### PR DESCRIPTION
## Summary

- Add `MultiscalePHATEModule` algorithm wrapper for hierarchical dimensionality reduction
- Uses diffusion condensation to identify stable resolutions and compute embeddings at multiple scales
- Enables stable connected component counting (β₀) across coarsening scales

## Key Features

| Method | Returns |
|--------|---------|
| `get_n_components_per_scale()` | β₀ trajectory across all scales |
| `get_stable_scales()` | Indices of stable resolutions |
| `get_gradient()` | Gradient profile for stability analysis |
| `get_n_stable_components()` | β₀ at most stable resolution |

## Files Changed

- `manylatents/algorithms/latent/multiscale_phate.py` - New algorithm wrapper
- `manylatents/configs/algorithms/latent/multiscale_phate.yaml` - Hydra config
- `manylatents/algorithms/latent/__init__.py` - Export registration
- `pyproject.toml`, `uv.lock` - Add `multiscale-phate` dependency

## Test plan

- [x] Basic fit/transform works
- [x] Multiscale accessors return expected shapes
- [ ] Integration test with manyLatents CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)