### PR TITLE
feat: Add multi-channel embedding support and MergingModule

### DIFF
--- a/manylatents/algorithms/latent/__init__.py
+++ b/manylatents/algorithms/latent/__init__.py
@@ -6,6 +6,7 @@ from .phate import PHATEModule
 from .multiscale_phate import MultiscalePHATEModule
 from .diffusion_map import DiffusionMapModule
 from .multi_dimensional_scaling import MDSModule
+from .merging import MergingModule
 
 __all__ = [
     "PCAModule",
@@ -15,4 +16,5 @@ __all__ = [
     "MultiscalePHATEModule",
     "DiffusionMapModule",
     "MDSModule",
+    "MergingModule",
 ]

--- a/manylatents/algorithms/latent/merging.py
+++ b/manylatents/algorithms/latent/merging.py
@@ -1,0 +1,201 @@
+"""Merging module for multi-channel embeddings.
+
+Merges embeddings from multiple channels using various strategies.
+Accepts embeddings from:
+1. In-memory dict of tensors
+2. DataModule with get_embeddings() method (e.g., PrecomputedDataModule)
+
+Example (in-memory):
+    >>> merger = MergingModule(
+    ...     embeddings={"dna": dna_tensor, "protein": protein_tensor},
+    ...     strategy="concat",
+    ... )
+    >>> merged = merger.fit_transform(dummy)
+
+Example (from datamodule):
+    >>> dm = PrecomputedDataModule(path="embs/", channels=["dna", "protein"])
+    >>> merger = MergingModule(strategy="concat", datamodule=dm)
+    >>> merged = merger.fit_transform(dummy)
+
+Example (Hydra CLI):
+    python -m manylatents.main \\
+        data=precomputed_embeddings \\
+        algorithms/latent=merging \\
+        algorithms.latent.strategy=concat
+"""
+from typing import Dict, List, Optional, Union
+
+import torch
+from torch import Tensor
+import numpy as np
+
+from .latent_module_base import LatentModule
+
+
+class MergingModule(LatentModule):
+    """Merge multi-channel embeddings into a single representation.
+
+    Supports multiple merging strategies:
+    - concat: Concatenate embeddings (default)
+    - weighted_sum: L2-normalize, scale by weights, sum
+    - mean: Average embeddings (requires equal dimensions)
+
+    Embeddings can be provided:
+    - Directly via `embeddings` parameter (in-memory)
+    - Via `datamodule.get_embeddings()` (file-based)
+
+    Args:
+        embeddings: Dict mapping channel names to tensors. If provided,
+            used directly instead of datamodule.
+        strategy: Merging strategy ('concat', 'weighted_sum', 'mean')
+        channels: Which channels to merge. None = all available.
+        weights: Channel weights for 'weighted_sum' strategy.
+            Missing channels default to 1.0.
+        normalize: L2-normalize each channel before merging.
+        n_components: Expected output dimension. Auto-computed if None.
+        **kwargs: Passed to LatentModule (datamodule, init_seed, etc.)
+
+    Attributes:
+        channel_dims: Dict of channel dimensions after setup.
+    """
+
+    STRATEGIES = ("concat", "weighted_sum", "mean")
+
+    def __init__(
+        self,
+        embeddings: Optional[Dict[str, Union[Tensor, np.ndarray]]] = None,
+        strategy: str = "concat",
+        channels: Optional[List[str]] = None,
+        weights: Optional[Dict[str, float]] = None,
+        normalize: bool = False,
+        n_components: Optional[int] = None,
+        **kwargs,
+    ):
+        if strategy not in self.STRATEGIES:
+            raise ValueError(
+                f"strategy must be one of {self.STRATEGIES}, got '{strategy}'"
+            )
+
+        super().__init__(n_components=n_components or 0, **kwargs)
+
+        # Convert numpy to torch if needed
+        if embeddings is not None:
+            self._embeddings = {
+                k: torch.from_numpy(v).float() if isinstance(v, np.ndarray) else v.float()
+                for k, v in embeddings.items()
+            }
+        else:
+            self._embeddings = None
+
+        self._strategy = strategy
+        self._channels = channels
+        self._weights = weights or {}
+        self._normalize = normalize
+
+        # Set after first transform
+        self.channel_dims: Dict[str, int] = {}
+
+    def _get_embeddings(self) -> Dict[str, Tensor]:
+        """Get embeddings from in-memory dict or datamodule."""
+        if self._embeddings is not None:
+            return self._embeddings
+
+        if self.datamodule is None:
+            raise ValueError(
+                "MergingModule requires either `embeddings` dict or `datamodule` "
+                "with get_embeddings() method."
+            )
+
+        if not hasattr(self.datamodule, "get_embeddings"):
+            raise ValueError(
+                f"Datamodule {type(self.datamodule).__name__} has no get_embeddings(). "
+                "Use PrecomputedDataModule with channels= parameter, or pass "
+                "embeddings= directly."
+            )
+
+        return self.datamodule.get_embeddings()
+
+    def fit(self, x: Tensor) -> None:
+        """No-op fit - merging doesn't require training."""
+        self._is_fitted = True
+
+    def transform(self, x: Tensor) -> Tensor:
+        """Merge embeddings from all channels.
+
+        Args:
+            x: Input tensor (ignored - embeddings from __init__ or datamodule)
+
+        Returns:
+            Merged embeddings of shape (N, merged_dim)
+        """
+        all_embeddings = self._get_embeddings()
+
+        # Select channels
+        channels = self._channels or list(all_embeddings.keys())
+
+        # Validate
+        missing = set(channels) - set(all_embeddings.keys())
+        if missing:
+            raise ValueError(
+                f"Channels not found: {missing}. "
+                f"Available: {list(all_embeddings.keys())}"
+            )
+
+        # Collect in order
+        embeddings = [all_embeddings[ch] for ch in channels]
+
+        # Record dimensions
+        self.channel_dims = {ch: e.shape[-1] for ch, e in zip(channels, embeddings)}
+
+        # Normalize if requested
+        if self._normalize:
+            embeddings = [
+                torch.nn.functional.normalize(e, p=2, dim=-1)
+                for e in embeddings
+            ]
+
+        # Apply strategy
+        if self._strategy == "concat":
+            merged = torch.cat(embeddings, dim=-1)
+
+        elif self._strategy == "weighted_sum":
+            self._validate_equal_dims(channels, embeddings)
+            weights = self._compute_weights(channels)
+            merged = sum(w * e for w, e in zip(weights, embeddings))
+
+        elif self._strategy == "mean":
+            self._validate_equal_dims(channels, embeddings)
+            merged = torch.stack(embeddings, dim=0).mean(dim=0)
+
+        else:
+            raise ValueError(f"Unknown strategy: {self._strategy}")
+
+        self.n_components = merged.shape[-1]
+        return merged
+
+    def _validate_equal_dims(self, channels: List[str], embeddings: List[Tensor]) -> None:
+        """Validate all embeddings have equal dimensions."""
+        dims = [e.shape[-1] for e in embeddings]
+        if len(set(dims)) > 1:
+            dim_info = dict(zip(channels, dims))
+            raise ValueError(
+                f"{self._strategy} requires equal dimensions, got {dim_info}. "
+                f"Use strategy='concat' or project to common dimension first."
+            )
+
+    def _compute_weights(self, channels: List[str]) -> List[float]:
+        """Compute normalized weights for channels."""
+        weights = [self._weights.get(ch, 1.0) for ch in channels]
+        total = sum(weights)
+        return [w / total for w in weights]
+
+    def get_channel_embeddings(self) -> Dict[str, Tensor]:
+        """Return individual channel embeddings (before merging)."""
+        return self._get_embeddings()
+
+    def __repr__(self) -> str:
+        channels_str = self._channels or "all"
+        return (
+            f"MergingModule(strategy='{self._strategy}', "
+            f"channels={channels_str}, normalize={self._normalize})"
+        )

--- a/manylatents/data/precomputed_datamodule.py
+++ b/manylatents/data/precomputed_datamodule.py
@@ -1,23 +1,44 @@
 import torch
 import numpy as np
-from typing import Optional, Union
+from pathlib import Path
+from typing import Dict, List, Optional, Union
 from lightning import LightningDataModule
 from torch.utils.data import DataLoader, random_split
-from .precomputed_dataset import PrecomputedDataset, InMemoryDataset
+from .precomputed_dataset import PrecomputedDataset, InMemoryDataset, MultiChannelDataset
 
 class PrecomputedDataModule(LightningDataModule):
     """
     DataModule for loading precomputed embeddings from files or directories,
     or from in-memory numpy arrays.
-    Supports both single files and multiple files from SaveEmbeddings.
+
+    Supports:
+    - Single files and multiple files from SaveEmbeddings
+    - Multi-channel embeddings via `channels` parameter (HDF5, .pt, or directory)
+
+    Multi-channel mode:
+        When `channels` is provided, loads multiple embedding channels and
+        provides `get_embeddings()` method returning Dict[str, Tensor].
+
+    Example (single-channel, backward compatible):
+        >>> dm = PrecomputedDataModule(path="embeddings.csv")
+
+    Example (multi-channel):
+        >>> dm = PrecomputedDataModule(
+        ...     path="embeddings/",
+        ...     channels=["dna_evo2", "protein_esm3"],
+        ... )
+        >>> dm.setup()
+        >>> embs = dm.get_embeddings()  # {"dna_evo2": Tensor, "protein_esm3": Tensor}
     """
     def __init__(
         self,
         path: Optional[str] = None,
         data: Optional[Union[np.ndarray, torch.Tensor]] = None,
+        channels: Optional[List[str]] = None,
         batch_size: int = 128,
         num_workers: int = 0,
         label_col: str = None,
+        labels_path: Optional[str] = None,
         mode: str = 'full',
         test_split: float = 0.2,
         seed: int = 42,
@@ -42,6 +63,9 @@ class PrecomputedDataModule(LightningDataModule):
         else:
             self.data_tensor = None
 
+        self.channels = channels
+        self._channel_embeddings: Dict[str, torch.Tensor] = {}
+        self._labels: Optional[np.ndarray] = None
         self.train_dataset = None
         self.test_dataset = None
 
@@ -49,6 +73,9 @@ class PrecomputedDataModule(LightningDataModule):
         if self.data_tensor is not None:
             # In-memory data path: use InMemoryDataset for EmbeddingOutputs compatibility
             full_dataset = InMemoryDataset(self.data_tensor)
+        elif self.channels is not None:
+            # Multi-channel mode: load each channel from path
+            full_dataset = self._setup_multi_channel()
         else:
             # File-based path: use PrecomputedDataset
             full_dataset = PrecomputedDataset(path=self.hparams.path, label_col=self.hparams.label_col)
@@ -66,6 +93,57 @@ class PrecomputedDataModule(LightningDataModule):
         else:
             raise ValueError(f"Mode '{self.hparams.mode}' is not supported. Use 'full' or 'split'.")
 
+    def _setup_multi_channel(self):
+        """Load multi-channel embeddings from directory or HDF5."""
+        path = Path(self.hparams.path)
+
+        for channel in self.channels:
+            # Try different file patterns
+            channel_path = None
+            for pattern in [f"{channel}.pt", f"{channel}.npy", f"{channel}.csv", channel]:
+                candidate = path / pattern
+                if candidate.exists():
+                    channel_path = candidate
+                    break
+
+            if channel_path is None:
+                raise FileNotFoundError(f"Channel '{channel}' not found in {path}")
+
+            # Load based on file type
+            if channel_path.suffix == ".pt":
+                data = torch.load(channel_path)
+                if isinstance(data, dict):
+                    emb = data.get("embeddings", data.get("data"))
+                    if emb is None:
+                        emb = next(iter(data.values()))  # Take first tensor
+                else:
+                    emb = data
+            elif channel_path.suffix == ".npy":
+                emb = torch.from_numpy(np.load(channel_path)).float()
+            elif channel_path.suffix == ".csv":
+                import pandas as pd
+                emb = torch.tensor(pd.read_csv(channel_path).values, dtype=torch.float32)
+            elif channel_path.is_dir():
+                # Load from directory
+                ds = PrecomputedDataset(str(channel_path))
+                emb = ds.data
+            else:
+                raise ValueError(f"Unsupported file type: {channel_path}")
+
+            self._channel_embeddings[channel] = emb
+
+        # Load labels if path provided
+        if self.hparams.labels_path:
+            labels_path = Path(self.hparams.labels_path)
+            if labels_path.suffix == ".npy":
+                self._labels = np.load(labels_path)
+            elif labels_path.suffix == ".pt":
+                data = torch.load(labels_path)
+                self._labels = data.get("labels", data).numpy() if isinstance(data, dict) else data.numpy()
+
+        # Create dataset with concatenated embeddings for compatibility
+        return MultiChannelDataset(self._channel_embeddings, self._labels)
+
     def train_dataloader(self) -> DataLoader:
         return DataLoader(
             self.train_dataset, batch_size=self.hparams.batch_size, num_workers=self.hparams.num_workers, shuffle=True
@@ -81,3 +159,52 @@ class PrecomputedDataModule(LightningDataModule):
         return DataLoader(
             self.test_dataset, batch_size=self.hparams.batch_size, num_workers=self.hparams.num_workers
         )
+
+    def get_embeddings(self) -> Dict[str, torch.Tensor]:
+        """Return dict of channel_name -> embeddings tensor.
+
+        Only available in multi-channel mode (when `channels` was provided).
+
+        Returns:
+            Dict mapping channel names to embedding tensors.
+            All tensors have same first dimension (aligned samples).
+
+        Raises:
+            ValueError: If not in multi-channel mode.
+        """
+        if not self._channel_embeddings:
+            if self.channels is not None:
+                self.setup()
+            else:
+                raise ValueError(
+                    "get_embeddings() only available in multi-channel mode. "
+                    "Provide `channels` parameter when creating PrecomputedDataModule."
+                )
+        return self._channel_embeddings
+
+    def get_labels(self) -> Optional[np.ndarray]:
+        """Return labels array if available."""
+        if self._labels is not None:
+            return self._labels
+        # Try to get from dataset
+        if hasattr(self.train_dataset, 'get_labels'):
+            return self.train_dataset.get_labels()
+        return None
+
+    def get_tensor(self) -> torch.Tensor:
+        """Return concatenated embeddings tensor for LatentModule compatibility.
+
+        In multi-channel mode, concatenates all channels.
+        In single-channel mode, returns the embeddings tensor.
+        """
+        if self._channel_embeddings:
+            # Multi-channel: concatenate in channel order
+            tensors = [self._channel_embeddings[ch] for ch in self.channels]
+            return torch.cat(tensors, dim=-1)
+        elif self.data_tensor is not None:
+            return self.data_tensor
+        elif self.train_dataset is not None:
+            return self.train_dataset.data
+        else:
+            self.setup()
+            return self.train_dataset.data


### PR DESCRIPTION
## Summary

- Add `MergingModule` LatentModule for merging multi-channel embeddings with strategies: concat, weighted_sum, mean
- Extend `PrecomputedDataModule` with `channels` parameter and `get_embeddings()` method for multi-channel loading
- Add `MultiChannelDataset` for handling aligned multi-channel embedding tensors

## API Design

### MergingModule - In-memory usage
```python
merger = MergingModule(
    embeddings={"dna": dna_tensor, "protein": protein_tensor},
    strategy="concat",
)
merged = merger.fit_transform(dummy)
```

### MergingModule - DataModule usage
```python
dm = PrecomputedDataModule(path="embs/", channels=["dna", "protein"])
merger = MergingModule(strategy="weighted_sum", weights={"dna": 0.7, "protein": 0.3}, datamodule=dm)
merged = merger.fit_transform(dummy)
```

### PrecomputedDataModule - Multi-channel
```python
dm = PrecomputedDataModule(
    path="embeddings/",
    channels=["dna_evo2", "protein_esm3"],
)
dm.setup()
embs = dm.get_embeddings()  # {"dna_evo2": Tensor, "protein_esm3": Tensor}
```

## Test plan

- [x] Unit test MergingModule with in-memory embeddings (concat, weighted_sum, mean)
- [x] Unit test MergingModule with datamodule.get_embeddings()
- [x] E2E test PrecomputedDataModule multi-channel loading
- [ ] Hydra config integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)