### PR TITLE
refactor: PlotEmbeddings with ColormapProvider protocol (#195)

### DIFF
--- a/manylatents/callbacks/embedding/plot_embeddings.py
+++ b/manylatents/callbacks/embedding/plot_embeddings.py
@@ -1,21 +1,39 @@
 import logging
 import os
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
-import scprep
-from matplotlib.colors import ListedColormap
+from matplotlib.colors import ListedColormap, Normalize
+from matplotlib.patches import Patch
 
 import wandb
-from manylatents.callbacks.embedding.base import EmbeddingCallback
-from manylatents.data.synthetic_dataset import DLAtree
-from manylatents.utils.mappings import cmap_dla_tree
+from manylatents.callbacks.embedding.base import (
+    EmbeddingCallback,
+    ColormapInfo,
+    ColormapProvider,
+)
 
 logger = logging.getLogger(__name__)
 
+
 class PlotEmbeddings(EmbeddingCallback):
+    """
+    Callback for plotting 2D embeddings with customizable colormaps and legends.
+
+    This callback creates scatter plots of embeddings, supporting:
+    - Categorical coloring with dict-based or ListedColormap colormaps
+    - Continuous coloring with colorbars
+    - Dataset-provided colormaps via the ColormapProvider protocol
+    - WandB integration for logging plots
+
+    The callback can be extended by:
+    - Overriding `_get_colormap()` for custom colormap logic
+    - Having datasets implement `ColormapProvider.get_colormap_info()`
+    """
+
     def __init__(
         self,
         save_dir: str = "outputs",
@@ -23,32 +41,35 @@ class PlotEmbeddings(EmbeddingCallback):
         figsize: tuple = (8, 6),
         label_col: str = "Population",
         legend: bool = False,
-        color_by_score: str = None,  # e.g. "tangent_space" or any metric key
+        color_by_score: str = None,
         x_label: str = "Dim 1",
         y_label: str = "Dim 2",
         title: str = "Dimensionality Reduction Plot",
-        apply_norm: bool = False,    ## EXPERIMENTAL, NOT INCONSISTENT IN TSA CASE
+        apply_norm: bool = False,
         alpha: float = 0.8,
-        log_key: str = "embedding_plot",  # Key for WandB logging, can be customized for step-aware logging
-        enable_wandb_upload: bool = True  # Whether to upload to WandB (if available)
+        log_key: str = "embedding_plot",
+        enable_wandb_upload: bool = True,
     ):
-        super().__init__()
         """
+        Initialize the PlotEmbeddings callback.
+
         Args:
-            save_dir (str): Directory where the plot will be saved.
-            experiment_name (str): Name of the experiment for the filename.
-            figsize (tuple): Figure size (width, height).
-            label_col (str): Column name in metadata to use for labels (fallback).
-            legend (bool): Whether to include a legend.
-            color_by_score (str): Optional key in embeddings to use for continuous score-based coloring.
-            x_label (str): Label for the x-axis.
-            y_label (str): Label for the y-axis.
-            title (str): Title for the plot.
-            apply_norm (bool): Whether to apply dynamic normalization to the color array.
-            alpha (float): Transparency of the points (0 = completely transparent, 1 = opaque).
-            log_key (str): Key for WandB logging. Can be customized for step-aware logging (e.g., "step_0/PCA/plot").
-            enable_wandb_upload (bool): Whether to upload to WandB when available. Set to False for offline mode.
+            save_dir: Directory where the plot will be saved.
+            experiment_name: Name of the experiment for the filename.
+            figsize: Figure size (width, height).
+            label_col: Column name in metadata to use for labels (fallback).
+            legend: Whether to include a legend for categorical data.
+            color_by_score: Optional key in embeddings to use for score-based coloring.
+                           Special value "tangent_space" enables categorical coloring.
+            x_label: Label for the x-axis.
+            y_label: Label for the y-axis.
+            title: Title for the plot.
+            apply_norm: Whether to apply dynamic normalization to continuous color arrays.
+            alpha: Transparency of the points (0 = transparent, 1 = opaque).
+            log_key: Key for WandB logging. Can be customized for step-aware logging.
+            enable_wandb_upload: Whether to upload to WandB when available.
         """
+        super().__init__()
         self.save_dir = save_dir
         self.experiment_name = experiment_name
         self.figsize = figsize
@@ -65,132 +86,225 @@ class PlotEmbeddings(EmbeddingCallback):
 
         os.makedirs(self.save_dir, exist_ok=True)
         logger.info(
-            f"PlotEmbeddings initialized with directory: {self.save_dir} and experiment name: {self.experiment_name}"
+            f"PlotEmbeddings initialized with directory: {self.save_dir} "
+            f"and experiment name: {self.experiment_name}"
         )
         if not enable_wandb_upload:
             logger.info("WandB upload disabled - running in offline mode")
 
-    def _get_colormap(self, dataset: any) -> any:
-        """Get colormap for plotting. Override this method in subclasses for dataset-specific colormaps."""
+    def _get_colormap(self, dataset: Any) -> ColormapInfo:
+        """
+        Get colormap information for plotting.
+
+        Resolution order:
+        1. If color_by_score is "tangent_space", return categorical colormap.
+        2. If color_by_score is set (continuous), return "viridis".
+        3. If dataset implements ColormapProvider protocol, use its colormap.
+        4. Fall back to "viridis".
+
+        This method can be overridden in subclasses for custom colormap logic,
+        particularly useful for downstream packages like manylatents-omics.
+
+        Args:
+            dataset: The dataset object, optionally implementing ColormapProvider.
+
+        Returns:
+            ColormapInfo containing the colormap and optional label names.
+        """
+        # Special case: tangent_space categorical coloring
         if self.color_by_score == "tangent_space":
-            # Define discrete colors for the two categories (adjust colors as needed)
-            return ListedColormap(["#1f77b4", "#ff7f0e"])
+            return ColormapInfo(
+                cmap=ListedColormap(["#1f77b4", "#ff7f0e"]),
+                label_names={0: "Dim ~ 1", 1: "Dim ~ 2"},
+                is_categorical=True,
+            )
+
+        # Continuous score coloring
         if self.color_by_score is not None:
-            return "viridis"
-        if isinstance(dataset, DLAtree):
-            # Check if we have more branches than colors in our palette
-            if hasattr(dataset, 'n_branch') and dataset.n_branch > 10:
-                logger.warning(f"DLA tree has {dataset.n_branch} branches but colormap only supports 10. Falling back to viridis.")
-                cmap = "viridis"
-            else:
-                cmap = cmap_dla_tree
-        else:
-            cmap = "viridis"
-        return cmap
+            return ColormapInfo(cmap="viridis", label_names=None, is_categorical=False)
+
+        # Dataset-provided colormap via protocol (no isinstance checks for specific types)
+        if isinstance(dataset, ColormapProvider):
+            return dataset.get_colormap_info()
+
+        # Fallback
+        return ColormapInfo(cmap="viridis", label_names=None, is_categorical=True)
 
     def _get_embeddings(self, embeddings: dict) -> np.ndarray:
-        embeddings = embeddings["embeddings"]
-        if hasattr(embeddings, "numpy"):
-            emb_np = embeddings.numpy()
-        else:
-            emb_np = embeddings
-        embeddings_to_plot = emb_np[:, :2] if emb_np.shape[1] > 2 else emb_np
-        return embeddings_to_plot[1:]
+        """
+        Extract and prepare embeddings for 2D plotting.
 
-    def _get_color_array(self, dataset: any, embeddings: dict) -> np.ndarray:
+        Args:
+            embeddings: Dictionary containing 'embeddings' key.
+
+        Returns:
+            2D numpy array of shape (n_samples, 2) for plotting.
+        """
+        emb = embeddings["embeddings"]
+
+        # Convert torch tensors to numpy
+        if hasattr(emb, "numpy"):
+            emb_np = emb.numpy()
+        elif hasattr(emb, "cpu"):  # Handle GPU tensors
+            emb_np = emb.cpu().numpy()
+        else:
+            emb_np = np.asarray(emb)
+
+        # Take first 2 dimensions for plotting
+        embeddings_to_plot = emb_np[:, :2] if emb_np.shape[1] > 2 else emb_np
+
+        return embeddings_to_plot
+
+    def _get_color_array(self, dataset: Any, embeddings: dict) -> Optional[np.ndarray]:
+        """
+        Extract color array for scatter plot coloring.
+
+        Resolution order:
+        1. If color_by_score is set, look in embeddings['scores'][key] or embeddings[key].
+        2. Use embeddings['label'] if available.
+        3. Fall back to dataset.get_labels().
+
+        Args:
+            dataset: Dataset object with optional get_labels() method.
+            embeddings: Dictionary potentially containing 'label' or 'scores'.
+
+        Returns:
+            Numpy array of colors/labels, or None if unavailable.
+        """
         color_array = None
+
         if self.color_by_score is not None:
+            # Try to get from scores dict first
             scores = embeddings.get("scores")
             if scores is not None and isinstance(scores, dict):
                 color_array = scores.get(self.color_by_score)
-            else:
+
+            # Fall back to direct key
+            if color_array is None:
                 color_array = embeddings.get(self.color_by_score)
+
             if color_array is None:
                 logger.warning(
-                    f"Coloring key '{self.color_by_score}' not found in embeddings; falling back to label-based coloring."
+                    f"Coloring key '{self.color_by_score}' not found; "
+                    "falling back to label-based coloring."
                 )
-                if "label" in embeddings and embeddings["label"] is not None:
-                    color_array = embeddings["label"]
-                else:
-                    color_array = dataset.get_labels(self.label_col)
             else:
                 logger.info(f"Using '{self.color_by_score}' for coloring.")
-        else:
+
+        # Label-based coloring fallback
+        if color_array is None:
             if "label" in embeddings and embeddings["label"] is not None:
                 color_array = embeddings["label"]
-            else:
-                color_array = dataset.get_labels(self.label_col)
+            elif hasattr(dataset, "get_labels"):
+                # Note: get_labels() doesn't take label_col argument in most implementations
+                try:
+                    color_array = dataset.get_labels(self.label_col)
+                except TypeError:
+                    # Fall back to no-argument version
+                    color_array = dataset.get_labels()
+
+        # Convert to numpy array
         if color_array is not None:
             if hasattr(color_array, "numpy"):
                 color_array = color_array.numpy()
+            elif hasattr(color_array, "cpu"):
+                color_array = color_array.cpu().numpy()
             color_array = np.asarray(color_array)
-            return color_array[1:]
+            return color_array
+
         return None
-    
-    def _plot_embeddings(self, dataset: any, embeddings_to_plot: np.ndarray, color_array: np.ndarray) -> str:
-        cmap = self._get_colormap(dataset)
-        fig_size = (self.figsize[0], self.figsize[1])
-        
-        norm = None
-        # For continuous scores, you may want to normalize. For tangent_space (categorical), skip normalization.
-        if self.color_by_score is not None and self.color_by_score != "tangent_space" and color_array is not None and self.apply_norm:
-            score_min = float(color_array.min())
-            score_max = float(color_array.max())
-            norm = mcolors.Normalize(vmin=score_min, vmax=score_max)
-        ax = scprep.plot.scatter2d(
-            embeddings_to_plot,
-            s=8,
-            figsize=fig_size,
-            cmap=cmap,
-            c=color_array,
-            ticks=False,
-            legend=self.legend,
-            xlabel=' ',
-            ylabel=' ',
-            legend_loc='upper center',
-            legend_anchor=(1.0, -0.02),
-            legend_ncol=8,
-            label_prefix=None,
-            title='',
-            fontsize=36,
-            alpha=self.alpha
+
+    def _apply_dict_colormap(
+        self, labels: np.ndarray, cmap_dict: Dict[Union[int, str], str]
+    ) -> List[str]:
+        """
+        Apply a dict-based colormap to label array.
+
+        Args:
+            labels: Array of label values (int or str).
+            cmap_dict: Mapping from label values to color strings.
+
+        Returns:
+            List of color strings for each point.
+        """
+        default_color = "#808080"  # Gray for unknown labels
+        return [cmap_dict.get(label, default_color) for label in labels]
+
+    def _add_categorical_legend(self, ax: plt.Axes, cmap_info: ColormapInfo) -> None:
+        """
+        Add categorical legend using ColormapInfo label_names.
+
+        Args:
+            ax: Matplotlib axes object.
+            cmap_info: ColormapInfo with label_names mapping.
+        """
+        if cmap_info.label_names is None:
+            return
+
+        patches = []
+        for idx, name in sorted(cmap_info.label_names.items()):
+            if isinstance(cmap_info.cmap, dict):
+                color = cmap_info.cmap.get(idx, "#808080")
+            elif isinstance(cmap_info.cmap, ListedColormap):
+                colors = cmap_info.cmap.colors
+                color = colors[idx % len(colors)]
+            else:
+                # String colormap name - get color from matplotlib
+                cmap = plt.colormaps.get_cmap(cmap_info.cmap)
+                max_idx = max(cmap_info.label_names.keys())
+                color = cmap(idx / max_idx) if max_idx > 0 else cmap(0)
+            patches.append(Patch(facecolor=color, label=name))
+
+        ax.legend(
+            handles=patches,
+            loc="upper center",
+            bbox_to_anchor=(0.5, -0.05),
+            ncol=min(8, len(patches)),
+            fontsize=8,
         )
-        
-        if norm is not None and ax.collections:
-            mappable = ax.collections[0]
-            mappable.set_norm(norm)
-            mappable.set_array(np.asarray(color_array))
-        
-        plt.xlabel(self.x_label, fontsize=12)
-        plt.ylabel(self.y_label, fontsize=12)
-        plt.title(self.title, fontsize=16)
-        
-        # For tangent_space, create a categorical legend
-        if self.color_by_score == "tangent_space":
-            from matplotlib.patches import Patch
-            # Adjust the colors to match those returned by _get_colormap (ListedColormap)
-            legend_elements = [
-                Patch(facecolor="#1f77b4", label="Dim ~ 1"),
-                Patch(facecolor="#ff7f0e", label="Dim ~ 2")
-            ]
-            plt.legend(handles=legend_elements, loc='upper right')
-        elif self.color_by_score is not None and ax.collections:
-            # For continuous scores, create a colorbar
-            mappable = ax.collections[0]
-            cbar = plt.colorbar(mappable)
-            cbar.set_label(f"{self.color_by_score} Score")
-        
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"embedding_plot_{self.experiment_name}_{timestamp}.png"
-        self.save_path = os.path.join(self.save_dir, filename)
 
-        os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
-        plt.savefig(self.save_path, bbox_inches="tight")
-        plt.close()
+    def _add_categorical_legend_from_data(
+        self,
+        ax: plt.Axes,
+        labels: np.ndarray,
+        cmap_info: ColormapInfo,
+    ) -> None:
+        """
+        Add categorical legend when no label_names provided, using unique labels from data.
 
-        logger.info(f"Saved 2D embeddings plot to {self.save_path}")
+        Args:
+            ax: Matplotlib axes object.
+            labels: Array of label values.
+            cmap_info: ColormapInfo containing the colormap.
+        """
+        unique_labels = sorted(set(labels))
 
-        # Only upload to WandB if enabled and WandB run is active
+        patches = []
+        for lbl in unique_labels:
+            if isinstance(cmap_info.cmap, dict):
+                color = cmap_info.cmap.get(lbl, "#808080")
+            elif isinstance(cmap_info.cmap, ListedColormap):
+                colors = cmap_info.cmap.colors
+                # For numeric labels, use as index; for others, use hash
+                idx = lbl if isinstance(lbl, (int, np.integer)) else hash(lbl)
+                color = colors[int(idx) % len(colors)]
+            else:
+                cmap = plt.colormaps.get_cmap(cmap_info.cmap)
+                n_unique = len(unique_labels)
+                idx = unique_labels.index(lbl)
+                color = cmap(idx / max(1, n_unique - 1))
+            patches.append(Patch(facecolor=color, label=str(lbl)))
+
+        ax.legend(
+            handles=patches,
+            loc="upper center",
+            bbox_to_anchor=(0.5, -0.05),
+            ncol=min(8, len(patches)),
+            fontsize=8,
+        )
+
+    def _upload_to_wandb(self) -> None:
+        """Upload plot to WandB if enabled and run is active."""
         if self.enable_wandb_upload and wandb.run is not None:
             wandb.log({self.log_key: wandb.Image(self.save_path)})
             logger.info(f"Uploaded plot to WandB with key: {self.log_key}")
@@ -199,9 +313,132 @@ class PlotEmbeddings(EmbeddingCallback):
         else:
             logger.info("WandB upload skipped (no active run)")
 
+    def _plot_embeddings(
+        self,
+        dataset: Any,
+        embeddings_to_plot: np.ndarray,
+        color_array: Optional[np.ndarray],
+    ) -> str:
+        """
+        Create and save the embedding scatter plot using matplotlib.
+
+        Args:
+            dataset: Dataset for colormap information.
+            embeddings_to_plot: 2D array of shape (n_samples, 2).
+            color_array: Array of colors/labels for each point.
+
+        Returns:
+            Path to the saved plot file.
+        """
+        cmap_info = self._get_colormap(dataset)
+
+        fig, ax = plt.subplots(figsize=self.figsize)
+
+        # Handle different colormap types
+        if cmap_info.is_categorical and isinstance(cmap_info.cmap, dict):
+            # Dict-based colormap: map labels to colors directly
+            if color_array is not None:
+                colors = self._apply_dict_colormap(color_array, cmap_info.cmap)
+                scatter = ax.scatter(
+                    embeddings_to_plot[:, 0],
+                    embeddings_to_plot[:, 1],
+                    c=colors,
+                    s=8,
+                    alpha=self.alpha,
+                )
+            else:
+                scatter = ax.scatter(
+                    embeddings_to_plot[:, 0],
+                    embeddings_to_plot[:, 1],
+                    s=8,
+                    alpha=self.alpha,
+                )
+
+            # Create categorical legend
+            if self.legend:
+                if cmap_info.label_names:
+                    self._add_categorical_legend(ax, cmap_info)
+                elif color_array is not None:
+                    self._add_categorical_legend_from_data(ax, color_array, cmap_info)
+
+        elif isinstance(cmap_info.cmap, ListedColormap):
+            # ListedColormap for discrete categories
+            scatter = ax.scatter(
+                embeddings_to_plot[:, 0],
+                embeddings_to_plot[:, 1],
+                c=color_array,
+                cmap=cmap_info.cmap,
+                s=8,
+                alpha=self.alpha,
+            )
+
+            if self.legend and cmap_info.label_names:
+                self._add_categorical_legend(ax, cmap_info)
+
+        else:
+            # String colormap name (continuous or categorical fallback)
+            norm = None
+            if (
+                not cmap_info.is_categorical
+                and self.apply_norm
+                and color_array is not None
+            ):
+                norm = Normalize(vmin=color_array.min(), vmax=color_array.max())
+
+            scatter = ax.scatter(
+                embeddings_to_plot[:, 0],
+                embeddings_to_plot[:, 1],
+                c=color_array,
+                cmap=cmap_info.cmap,
+                norm=norm,
+                s=8,
+                alpha=self.alpha,
+            )
+
+            # Add colorbar for continuous data
+            if not cmap_info.is_categorical and self.color_by_score:
+                cbar = plt.colorbar(scatter, ax=ax)
+                cbar.set_label(f"{self.color_by_score} Score")
+            elif self.legend and cmap_info.is_categorical and color_array is not None:
+                # Categorical with string colormap
+                self._add_categorical_legend_from_data(ax, color_array, cmap_info)
+
+        # Configure axes
+        ax.set_xlabel(self.x_label, fontsize=12)
+        ax.set_ylabel(self.y_label, fontsize=12)
+        ax.set_title(self.title, fontsize=16)
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+        # Save figure
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"embedding_plot_{self.experiment_name}_{timestamp}.png"
+        self.save_path = os.path.join(self.save_dir, filename)
+
+        os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
+        plt.savefig(self.save_path, bbox_inches="tight", dpi=150)
+        plt.close(fig)
+
+        logger.info(f"Saved 2D embeddings plot to {self.save_path}")
+
+        # WandB upload
+        self._upload_to_wandb()
+
         return self.save_path
 
-    def on_latent_end(self, dataset: any, embeddings: dict) -> str:
+    def on_latent_end(self, dataset: Any, embeddings: dict) -> dict:
+        """
+        Called when the latent process is complete.
+
+        Creates a 2D scatter plot of the embeddings and optionally uploads to WandB.
+
+        Args:
+            dataset: A dataset object that may implement ColormapProvider.
+            embeddings: Dictionary containing 'embeddings' and optionally 'label', 'scores'.
+
+        Returns:
+            Dictionary containing callback outputs including 'embedding_plot_path'.
+        """
         emb2d = self._get_embeddings(embeddings)
         colors = self._get_color_array(dataset, embeddings)
         path = self._plot_embeddings(dataset, emb2d, colors)

--- a/tests/callbacks/test_plot_embeddings.py
+++ b/tests/callbacks/test_plot_embeddings.py
@@ -1,0 +1,356 @@
+"""Tests for PlotEmbeddings callback."""
+
+import os
+import tempfile
+from typing import Optional
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+from manylatents.callbacks.embedding.base import ColormapInfo, ColormapProvider
+from manylatents.callbacks.embedding.plot_embeddings import PlotEmbeddings
+from matplotlib.colors import ListedColormap
+
+
+class MockDataset:
+    """Mock dataset without colormap support."""
+
+    def __init__(self, labels: np.ndarray):
+        self._labels = labels
+
+    def get_labels(self, col: str = None) -> np.ndarray:
+        return self._labels
+
+
+class MockDatasetWithColormap:
+    """Mock dataset implementing ColormapProvider protocol."""
+
+    def __init__(self, labels: np.ndarray, cmap_info: ColormapInfo):
+        self._labels = labels
+        self._cmap_info = cmap_info
+
+    def get_labels(self, col: str = None) -> np.ndarray:
+        return self._labels
+
+    def get_colormap_info(self) -> ColormapInfo:
+        return self._cmap_info
+
+
+class TestPlotEmbeddingsInit:
+    """Tests for PlotEmbeddings initialization."""
+
+    def test_init_default_params(self):
+        """Test default initialization."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+            assert callback.legend is False
+            assert callback.color_by_score is None
+            assert callback.alpha == 0.8
+            assert callback.enable_wandb_upload is True
+
+    def test_init_custom_params(self):
+        """Test initialization with custom parameters."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(
+                save_dir=tmpdir,
+                legend=True,
+                alpha=0.5,
+                color_by_score="test_score",
+                enable_wandb_upload=False,
+            )
+            assert callback.legend is True
+            assert callback.alpha == 0.5
+            assert callback.color_by_score == "test_score"
+            assert callback.enable_wandb_upload is False
+
+    def test_init_creates_save_dir(self):
+        """Test that initialization creates the save directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "new_subdir")
+            callback = PlotEmbeddings(save_dir=subdir)
+            assert os.path.exists(subdir)
+
+
+class TestGetColormap:
+    """Tests for _get_colormap method."""
+
+    def test_tangent_space_colormap(self):
+        """Test tangent_space special case returns ListedColormap."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, color_by_score="tangent_space")
+            cmap_info = callback._get_colormap(MockDataset(np.array([0, 1])))
+
+            assert cmap_info.is_categorical is True
+            assert cmap_info.label_names == {0: "Dim ~ 1", 1: "Dim ~ 2"}
+            assert isinstance(cmap_info.cmap, ListedColormap)
+
+    def test_continuous_score_colormap(self):
+        """Test continuous score coloring returns viridis."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, color_by_score="some_metric")
+            cmap_info = callback._get_colormap(MockDataset(np.array([0, 1])))
+
+            assert cmap_info.cmap == "viridis"
+            assert cmap_info.is_categorical is False
+
+    def test_dataset_provided_colormap(self):
+        """Test dataset with ColormapProvider is used."""
+        custom_cmap = ColormapInfo(
+            cmap={"A": "red", "B": "blue"},
+            label_names={0: "Label A", 1: "Label B"},
+            is_categorical=True,
+        )
+        dataset = MockDatasetWithColormap(np.array(["A", "B"]), custom_cmap)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+            cmap_info = callback._get_colormap(dataset)
+
+            assert cmap_info.cmap == {"A": "red", "B": "blue"}
+            assert cmap_info.label_names == {0: "Label A", 1: "Label B"}
+
+    def test_fallback_colormap(self):
+        """Test fallback to viridis for basic dataset."""
+        dataset = MockDataset(np.array([0, 1, 2]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+            cmap_info = callback._get_colormap(dataset)
+
+            assert cmap_info.cmap == "viridis"
+            assert cmap_info.is_categorical is True
+
+
+class TestGetEmbeddings:
+    """Tests for _get_embeddings method."""
+
+    def test_no_skip_first_element(self):
+        """Verify [1:] skip is removed - all elements returned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {"embeddings": np.array([[1, 2], [3, 4], [5, 6]])}
+            result = callback._get_embeddings(embeddings)
+
+            # Should return all 3 rows, not 2
+            assert result.shape == (3, 2)
+            np.testing.assert_array_equal(result[0], [1, 2])
+
+    def test_truncates_to_2d(self):
+        """Test high-dimensional embeddings are truncated to 2D."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {"embeddings": np.random.randn(10, 50)}
+            result = callback._get_embeddings(embeddings)
+
+            assert result.shape == (10, 2)
+
+    def test_handles_torch_tensor(self):
+        """Test conversion from torch tensor."""
+        import torch
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {"embeddings": torch.tensor([[1.0, 2.0], [3.0, 4.0]])}
+            result = callback._get_embeddings(embeddings)
+
+            assert isinstance(result, np.ndarray)
+            assert result.shape == (2, 2)
+
+
+class TestGetColorArray:
+    """Tests for _get_color_array method."""
+
+    def test_no_skip_first_element(self):
+        """Verify [1:] skip is removed for color array."""
+        dataset = MockDataset(np.array([0, 1, 2, 3]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {"label": np.array([0, 1, 2, 3])}
+            result = callback._get_color_array(dataset, embeddings)
+
+            # Should return all 4 elements
+            assert len(result) == 4
+
+    def test_uses_embeddings_label(self):
+        """Test embeddings['label'] takes precedence over dataset."""
+        dataset = MockDataset(np.array([10, 20, 30]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {"label": np.array([0, 1, 2])}
+            result = callback._get_color_array(dataset, embeddings)
+
+            np.testing.assert_array_equal(result, [0, 1, 2])
+
+    def test_fallback_to_dataset_labels(self):
+        """Test fallback to dataset.get_labels() when no embeddings label."""
+        dataset = MockDataset(np.array([10, 20, 30]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            embeddings = {}
+            result = callback._get_color_array(dataset, embeddings)
+
+            np.testing.assert_array_equal(result, [10, 20, 30])
+
+    def test_color_by_score_from_scores_dict(self):
+        """Test color_by_score retrieves from scores dict."""
+        dataset = MockDataset(np.array([0, 1]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, color_by_score="my_metric")
+
+            embeddings = {"scores": {"my_metric": np.array([0.5, 0.8])}}
+            result = callback._get_color_array(dataset, embeddings)
+
+            np.testing.assert_array_equal(result, [0.5, 0.8])
+
+    def test_color_by_score_fallback_to_label(self):
+        """Test color_by_score falls back to label if metric not found."""
+        dataset = MockDataset(np.array([0, 1]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, color_by_score="missing_metric")
+
+            embeddings = {"label": np.array([5, 6])}
+            result = callback._get_color_array(dataset, embeddings)
+
+            np.testing.assert_array_equal(result, [5, 6])
+
+
+class TestApplyDictColormap:
+    """Tests for _apply_dict_colormap method."""
+
+    def test_apply_dict_colormap(self):
+        """Test dict colormap maps labels to colors."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            labels = np.array([1, 2, 1, 3])
+            cmap_dict = {1: "red", 2: "blue", 3: "green"}
+
+            colors = callback._apply_dict_colormap(labels, cmap_dict)
+
+            assert colors == ["red", "blue", "red", "green"]
+
+    def test_apply_dict_colormap_missing_label(self):
+        """Test dict colormap handles missing labels with gray."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir)
+
+            labels = np.array([1, 99])  # 99 not in dict
+            cmap_dict = {1: "red"}
+
+            colors = callback._apply_dict_colormap(labels, cmap_dict)
+
+            assert colors[0] == "red"
+            assert colors[1] == "#808080"  # Default gray
+
+
+class TestOnLatentEnd:
+    """Integration tests for full callback execution."""
+
+    @patch("wandb.run", None)  # Disable wandb
+    def test_full_pipeline(self):
+        """Test complete callback execution."""
+        dataset = MockDataset(np.array([0, 1, 0, 1]))
+        embeddings = {
+            "embeddings": np.array([[0, 0], [1, 1], [0.5, 0.5], [1.5, 1.5]]),
+            "label": np.array([0, 1, 0, 1]),
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, enable_wandb_upload=False)
+
+            result = callback.on_latent_end(dataset, embeddings)
+
+            # Verify file was created
+            assert "embedding_plot_path" in result
+            assert os.path.exists(result["embedding_plot_path"])
+            assert result["embedding_plot_path"].endswith(".png")
+
+    @patch("wandb.run", None)
+    def test_full_pipeline_with_legend(self):
+        """Test callback with legend enabled."""
+        dataset = MockDataset(np.array([0, 1, 2]))
+        embeddings = {
+            "embeddings": np.array([[0, 0], [1, 1], [2, 2]]),
+            "label": np.array([0, 1, 2]),
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, legend=True, enable_wandb_upload=False)
+
+            result = callback.on_latent_end(dataset, embeddings)
+
+            assert "embedding_plot_path" in result
+            assert os.path.exists(result["embedding_plot_path"])
+
+    @patch("wandb.run", None)
+    def test_full_pipeline_with_colormap_provider(self):
+        """Test callback with dataset implementing ColormapProvider."""
+        custom_cmap = ColormapInfo(
+            cmap={0: "#ff0000", 1: "#00ff00"},
+            label_names={0: "Red Class", 1: "Green Class"},
+            is_categorical=True,
+        )
+        dataset = MockDatasetWithColormap(np.array([0, 1, 0, 1]), custom_cmap)
+        embeddings = {
+            "embeddings": np.array([[0, 0], [1, 1], [0.5, 0.5], [1.5, 1.5]]),
+            "label": np.array([0, 1, 0, 1]),
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, legend=True, enable_wandb_upload=False)
+
+            result = callback.on_latent_end(dataset, embeddings)
+
+            assert "embedding_plot_path" in result
+            assert os.path.exists(result["embedding_plot_path"])
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility with existing code."""
+
+    def test_callback_outputs_dict_returned(self):
+        """Test that on_latent_end returns callback_outputs dict."""
+        dataset = MockDataset(np.array([0, 1]))
+        embeddings = {
+            "embeddings": np.array([[0, 0], [1, 1]]),
+            "label": np.array([0, 1]),
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = PlotEmbeddings(save_dir=tmpdir, enable_wandb_upload=False)
+
+            with patch("wandb.run", None):
+                result = callback.on_latent_end(dataset, embeddings)
+
+            assert isinstance(result, dict)
+            assert "embedding_plot_path" in result
+
+    def test_overridable_get_colormap(self):
+        """Test that _get_colormap can be overridden in subclasses."""
+
+        class CustomPlotEmbeddings(PlotEmbeddings):
+            def _get_colormap(self, dataset):
+                return ColormapInfo(
+                    cmap={"custom": "purple"},
+                    label_names={0: "Custom Label"},
+                    is_categorical=True,
+                )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            callback = CustomPlotEmbeddings(save_dir=tmpdir)
+            cmap_info = callback._get_colormap(MockDataset(np.array([0])))
+
+            assert cmap_info.cmap == {"custom": "purple"}
+            assert cmap_info.label_names == {0: "Custom Label"}


### PR DESCRIPTION
- Remove scprep dependency, use pure matplotlib for scatter plots
- Remove magic [1:] skip in _get_embeddings() and _get_color_array()
- Replace isinstance(dataset, DLAtree) checks with ColormapProvider protocol
- Add ColormapInfo dataclass and ColormapProvider protocol to base.py
- Add get_colormap_info() to SyntheticDataset, DLAtree, DLATreeFromGraph
- Add helper methods for dict colormap application and legend creation
- Add comprehensive test suite (22 tests)

Closes #195