### PR TITLE
refactor: deprecate eval_only parameter

### DIFF
--- a/manylatents/configs/config.py
+++ b/manylatents/configs/config.py
@@ -65,8 +65,5 @@ class Config:
     project: str = "default"
     """Project name for logging and tracking."""
     
-    eval_only: bool = False
-    """If True, skip training and only run evaluation (or plotting) using precomputed embeddings or a pretrained network."""
-    
     pretrained_ckpt: Optional[str] = None
     """If specified, load a pretrained checkpoint to compute embeddings instead of training a new model."""


### PR DESCRIPTION
## Summary
- Remove `eval_only` field from Config schema
- Remove early return block in `run_algorithm()` that bypassed algorithm dispatch
- Simplify LightningModule handling: use `pretrained_ckpt` directly

## Changes
- `manylatents/configs/config.py`: Remove `eval_only` field
- `manylatents/experiment.py`: Remove `eval_only` checks, simplify logic

## Test plan
- [x] All `eval_only` references removed from Python code
- [ ] Existing workflows continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)