### PR TITLE
fix: accept shuffle_traindata in PrecomputedDataModule

### DIFF
--- a/manylatents/data/precomputed_datamodule.py
+++ b/manylatents/data/precomputed_datamodule.py
@@ -42,6 +42,7 @@ class PrecomputedDataModule(LightningDataModule):
         channels: Optional[List[str]] = None,
         batch_size: int = 128,
         num_workers: int = 0,
+        shuffle_traindata: bool = False,
         label_col: str = None,
         labels_path: Optional[str] = None,
         metadata_path: Optional[str] = None,


### PR DESCRIPTION
## Summary
- PrecomputedDataModule now accepts `shuffle_traindata` from inherited `data/default.yaml`
- Without this, `data=precomputed` fails at Hydra instantiation when defaults inject `shuffle_traindata: True`

## Test plan
- [ ] CI passes (existing tests cover PrecomputedDataModule)
- [ ] `data=precomputed` works with default data config inheritance

🤖 Generated with [Claude Code](https://claude.com/claude-code)