### PR TITLE
feat: add timing to EmbeddingOutputs

### DIFF
--- a/manylatents/callbacks/embedding/__init__.py
+++ b/manylatents/callbacks/embedding/__init__.py
@@ -1,11 +1,14 @@
 """Embedding-level callbacks for post-processing latent outputs."""
 from manylatents.callbacks.embedding.base import EmbeddingCallback, EmbeddingOutputs
 from manylatents.callbacks.embedding.save_embeddings import SaveEmbeddings
+from manylatents.callbacks.embedding.save_trajectory import SaveTrajectory, load_trajectory
 from manylatents.callbacks.embedding.loadings_analysis import LoadingsAnalysisCallback
 
 __all__ = [
     "EmbeddingCallback",
     "EmbeddingOutputs",
     "SaveEmbeddings",
+    "SaveTrajectory",
     "LoadingsAnalysisCallback",
+    "load_trajectory",
 ]

--- a/manylatents/callbacks/embedding/save_trajectory.py
+++ b/manylatents/callbacks/embedding/save_trajectory.py
@@ -1,0 +1,178 @@
+"""SaveTrajectory callback — writes per-step embedding snapshots to disk.
+
+Also provides ``load_trajectory()`` for reading back what was written,
+returning ``list[EmbeddingOutputs]`` (one dict per step).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from manylatents.callbacks.embedding.base import EmbeddingCallback, EmbeddingOutputs
+
+logger = logging.getLogger(__name__)
+
+
+class SaveTrajectory(EmbeddingCallback):
+    """Write trajectory manifest + per-step NPY files from pipeline snapshots.
+
+    Reads ``step_snapshots`` from the embeddings dict (populated by
+    ``run_pipeline``) and writes:
+
+    - ``trajectory.json`` — manifest with step metadata and file references
+    - ``step_{i}_embedding.npy`` — embedding array for each step
+
+    If ``step_snapshots`` is absent (single-algorithm run), falls back to
+    saving the final embedding as a single-step trajectory.
+    """
+
+    def __init__(
+        self,
+        save_dir: str = "outputs",
+        experiment_name: str = "experiment",
+    ) -> None:
+        super().__init__()
+        self.save_dir = save_dir
+        self.experiment_name = experiment_name
+        os.makedirs(self.save_dir, exist_ok=True)
+
+    def on_latent_end(self, dataset, embeddings: dict) -> dict:
+        snapshots = embeddings.get("step_snapshots")
+
+        if snapshots:
+            steps_meta = self._write_snapshots(snapshots)
+        else:
+            # Single-algorithm run: synthesize a one-step trajectory
+            final_emb = embeddings["embeddings"]
+            if not isinstance(final_emb, np.ndarray):
+                final_emb = np.asarray(final_emb)
+            npy_name = "step_0_embedding.npy"
+            np.save(os.path.join(self.save_dir, npy_name), final_emb)
+
+            algo = (embeddings.get("metadata", {})
+                    .get("final_algorithm_type", "unknown"))
+            steps_meta = [{
+                "step_index": 0,
+                "step_name": "single_step",
+                "algorithm": algo,
+                "output_shape": list(final_emb.shape),
+                "embedding_file": npy_name,
+                "step_time": None,
+            }]
+
+        # Save label array if present
+        label = embeddings.get("label")
+        label_file = None
+        if label is not None:
+            label_arr = label if isinstance(label, np.ndarray) else np.asarray(label)
+            label_file = "label.npy"
+            np.save(os.path.join(self.save_dir, label_file), label_arr)
+
+        final_emb = embeddings["embeddings"]
+        if not isinstance(final_emb, np.ndarray):
+            final_emb = np.asarray(final_emb)
+
+        scores = embeddings.get("scores", {})
+        # Flatten (scalar, array) tuples to just the scalar for the manifest
+        flat_scores = {}
+        for k, v in scores.items():
+            if isinstance(v, tuple) and len(v) == 2:
+                flat_scores[k] = float(v[0])
+            elif isinstance(v, (int, float)):
+                flat_scores[k] = float(v)
+            else:
+                try:
+                    flat_scores[k] = float(v)
+                except (TypeError, ValueError):
+                    pass  # skip non-scalar scores in manifest
+
+        manifest = {
+            "version": "1.0",
+            "experiment_name": self.experiment_name,
+            "steps": steps_meta,
+            "final_shape": list(final_emb.shape),
+            "scores": flat_scores,
+            "label_file": label_file,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        manifest_path = os.path.join(self.save_dir, "trajectory.json")
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+
+        logger.info(
+            f"SaveTrajectory: wrote {len(steps_meta)} step(s) to {self.save_dir}"
+        )
+
+        self.register_output("trajectory_manifest", manifest_path)
+        return self.callback_outputs
+
+    def _write_snapshots(self, snapshots: list) -> list:
+        """Write per-step NPY files and return manifest step entries."""
+        steps_meta = []
+        for snap in snapshots:
+            idx = snap["step_index"]
+            npy_name = f"step_{idx}_embedding.npy"
+            np.save(os.path.join(self.save_dir, npy_name), snap["embedding"])
+            steps_meta.append({
+                "step_index": idx,
+                "step_name": snap["step_name"],
+                "algorithm": snap["algorithm"],
+                "output_shape": snap["output_shape"],
+                "embedding_file": npy_name,
+                "step_time": snap.get("step_time"),
+            })
+        return steps_meta
+
+
+def load_trajectory(path: str | Path) -> list[EmbeddingOutputs]:
+    """Read a trajectory directory written by :class:`SaveTrajectory`.
+
+    Returns one :data:`EmbeddingOutputs` dict per pipeline step, ordered by
+    step index.  Scores are attached to the **last** step only (that is where
+    ``run_pipeline`` evaluates metrics).
+
+    Parameters
+    ----------
+    path : str | Path
+        Directory containing ``trajectory.json`` and the referenced NPY files.
+
+    Returns
+    -------
+    list[EmbeddingOutputs]
+        One dict per step with keys: ``embeddings``, ``label`` (or ``None``),
+        ``metadata``, ``scores``.
+    """
+    path = Path(path)
+    with open(path / "trajectory.json") as f:
+        manifest = json.load(f)
+
+    # Load label once (shared across all steps)
+    label_file = manifest.get("label_file")
+    label = np.load(path / label_file) if label_file else None
+
+    steps = manifest["steps"]
+    scores = manifest.get("scores", {})
+    result: list[EmbeddingOutputs] = []
+
+    for i, step in enumerate(steps):
+        is_last = i == len(steps) - 1
+        result.append({
+            "embeddings": np.load(path / step["embedding_file"]),
+            "label": label,
+            "metadata": {
+                "step_index": step["step_index"],
+                "step_name": step["step_name"],
+                "algorithm": step["algorithm"],
+                "step_time": step.get("step_time"),
+            },
+            "scores": scores if is_last else {},
+        })
+
+    return result

--- a/manylatents/configs/callbacks/embedding/save_trajectory.yaml
+++ b/manylatents/configs/callbacks/embedding/save_trajectory.yaml
@@ -1,0 +1,4 @@
+save_trajectory:
+  _target_: manylatents.callbacks.embedding.save_trajectory.SaveTrajectory
+  save_dir: ${hydra:runtime.output_dir}
+  experiment_name: ${name}

--- a/tests/callbacks/test_save_trajectory.py
+++ b/tests/callbacks/test_save_trajectory.py
@@ -1,0 +1,332 @@
+"""Tests for SaveTrajectory callback and load_trajectory round-trip."""
+
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from manylatents.callbacks.embedding.save_trajectory import SaveTrajectory, load_trajectory
+
+
+def _make_embeddings_with_snapshots(n_samples=100):
+    """Build an embeddings dict with step_snapshots, mimicking run_pipeline output."""
+    return {
+        "embeddings": np.random.randn(n_samples, 2),
+        "scores": {"participation_ratio": 1.93, "trustworthiness": 0.87},
+        "metadata": {"source": "pipeline", "num_steps": 2},
+        "step_snapshots": [
+            {
+                "step_index": 0,
+                "step_name": "pca_step",
+                "algorithm": "PCA",
+                "output_shape": [n_samples, 50],
+                "embedding": np.random.randn(n_samples, 50),
+                "step_time": 0.123,
+            },
+            {
+                "step_index": 1,
+                "step_name": "umap_step",
+                "algorithm": "UMAP",
+                "output_shape": [n_samples, 2],
+                "embedding": np.random.randn(n_samples, 2),
+                "step_time": 0.456,
+            },
+        ],
+    }
+
+
+def _make_single_algorithm_embeddings(n_samples=100):
+    """Embeddings dict without step_snapshots (single-algorithm run)."""
+    return {
+        "embeddings": np.random.randn(n_samples, 2),
+        "scores": {"participation_ratio": 1.5},
+        "metadata": {
+            "source": "pipeline",
+            "num_steps": 1,
+            "final_algorithm_type": "PCA",
+        },
+    }
+
+
+class TestSaveTrajectory:
+
+    def test_writes_manifest_and_npy_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="test_exp")
+            embeddings = _make_embeddings_with_snapshots(n_samples=80)
+
+            result = cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            # Manifest exists
+            manifest_path = os.path.join(tmpdir, "trajectory.json")
+            assert os.path.exists(manifest_path)
+
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+            assert manifest["version"] == "1.0"
+            assert manifest["experiment_name"] == "test_exp"
+            assert len(manifest["steps"]) == 2
+            assert manifest["final_shape"] == [80, 2]
+            assert "timestamp" in manifest
+
+            # Per-step NPY files exist with correct shapes
+            for step in manifest["steps"]:
+                npy_path = os.path.join(tmpdir, step["embedding_file"])
+                assert os.path.exists(npy_path)
+                arr = np.load(npy_path)
+                assert list(arr.shape) == step["output_shape"]
+
+    def test_manifest_step_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="meta_test")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            s0 = manifest["steps"][0]
+            assert s0["step_index"] == 0
+            assert s0["step_name"] == "pca_step"
+            assert s0["algorithm"] == "PCA"
+            assert s0["embedding_file"] == "step_0_embedding.npy"
+
+            s1 = manifest["steps"][1]
+            assert s1["step_index"] == 1
+            assert s1["step_name"] == "umap_step"
+            assert s1["algorithm"] == "UMAP"
+
+    def test_scores_in_manifest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="scores")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert manifest["scores"]["participation_ratio"] == pytest.approx(1.93)
+            assert manifest["scores"]["trustworthiness"] == pytest.approx(0.87)
+
+    def test_tuple_scores_flattened(self):
+        """Scores stored as (scalar, array) tuples should use the scalar."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="tuples")
+            embeddings = _make_embeddings_with_snapshots()
+            embeddings["scores"]["knn_recall"] = (0.95, np.ones(100))
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert manifest["scores"]["knn_recall"] == pytest.approx(0.95)
+
+    def test_single_algorithm_fallback(self):
+        """Without step_snapshots, should save final embedding as single-step trajectory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="single")
+            embeddings = _make_single_algorithm_embeddings(n_samples=60)
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert len(manifest["steps"]) == 1
+            step = manifest["steps"][0]
+            assert step["step_name"] == "single_step"
+            assert step["algorithm"] == "PCA"
+            assert step["embedding_file"] == "step_0_embedding.npy"
+
+            arr = np.load(os.path.join(tmpdir, "step_0_embedding.npy"))
+            assert arr.shape == (60, 2)
+
+    def test_registers_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="reg")
+            embeddings = _make_embeddings_with_snapshots()
+
+            result = cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            assert "trajectory_manifest" in result
+            assert result["trajectory_manifest"].endswith("trajectory.json")
+
+    def test_empty_scores(self):
+        """Should handle embeddings with no scores gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="no_scores")
+            embeddings = _make_embeddings_with_snapshots()
+            embeddings["scores"] = {}
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert manifest["scores"] == {}
+
+    def test_saves_label_when_present(self):
+        """Label array should be written as label.npy and referenced in manifest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="label_test")
+            embeddings = _make_embeddings_with_snapshots(n_samples=50)
+            embeddings["label"] = np.arange(50)
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert manifest["label_file"] == "label.npy"
+            label = np.load(os.path.join(tmpdir, "label.npy"))
+            np.testing.assert_array_equal(label, np.arange(50))
+
+    def test_label_file_null_when_absent(self):
+        """Manifest should have label_file: null when no label is provided."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="no_label")
+            embeddings = _make_embeddings_with_snapshots()
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            with open(os.path.join(tmpdir, "trajectory.json")) as f:
+                manifest = json.load(f)
+
+            assert manifest["label_file"] is None
+
+
+class TestLoadTrajectory:
+
+    def test_round_trip_with_snapshots(self):
+        """Write via SaveTrajectory, read via load_trajectory, verify contents."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="round_trip")
+            embeddings = _make_embeddings_with_snapshots(n_samples=80)
+            embeddings["label"] = np.arange(80)
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+            result = load_trajectory(tmpdir)
+
+            assert len(result) == 2
+
+    def test_each_element_has_embedding_outputs_keys(self):
+        """Every element should have embeddings, label, metadata, scores."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="keys_test")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            for step in result:
+                assert "embeddings" in step
+                assert "label" in step
+                assert "metadata" in step
+                assert "scores" in step
+                assert isinstance(step["embeddings"], np.ndarray)
+
+    def test_embedding_shapes_match(self):
+        """Loaded embedding shapes should match what was written."""
+        n = 60
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="shapes")
+            embeddings = _make_embeddings_with_snapshots(n_samples=n)
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            assert result[0]["embeddings"].shape == (n, 50)  # PCA step
+            assert result[1]["embeddings"].shape == (n, 2)   # UMAP step
+
+    def test_label_round_trip_present(self):
+        """Label should round-trip correctly when present."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="label_rt")
+            embeddings = _make_embeddings_with_snapshots(n_samples=40)
+            expected_label = np.array([0, 1, 2, 3] * 10)
+            embeddings["label"] = expected_label
+
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+            result = load_trajectory(tmpdir)
+
+            for step in result:
+                np.testing.assert_array_equal(step["label"], expected_label)
+
+    def test_label_none_when_absent(self):
+        """Label should be None when not saved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="no_label")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            for step in result:
+                assert step["label"] is None
+
+    def test_scores_only_on_last_step(self):
+        """Scores should only appear on the last step."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="scores_last")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            # First step: no scores
+            assert result[0]["scores"] == {}
+            # Last step: has scores
+            assert result[-1]["scores"]["participation_ratio"] == pytest.approx(1.93)
+            assert result[-1]["scores"]["trustworthiness"] == pytest.approx(0.87)
+
+    def test_metadata_has_required_fields(self):
+        """Each step's metadata should have step_index, step_name, algorithm."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="meta")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+
+            assert result[0]["metadata"]["step_index"] == 0
+            assert result[0]["metadata"]["step_name"] == "pca_step"
+            assert result[0]["metadata"]["algorithm"] == "PCA"
+
+            assert result[1]["metadata"]["step_index"] == 1
+            assert result[1]["metadata"]["step_name"] == "umap_step"
+            assert result[1]["metadata"]["algorithm"] == "UMAP"
+
+    def test_step_time_round_trip(self):
+        """step_time should round-trip through SaveTrajectory → manifest → load_trajectory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="timing_rt")
+            embeddings = _make_embeddings_with_snapshots()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+
+            assert result[0]["metadata"]["step_time"] == pytest.approx(0.123)
+            assert result[1]["metadata"]["step_time"] == pytest.approx(0.456)
+
+    def test_step_time_none_for_single_algorithm(self):
+        """Single-algorithm fallback should have step_time=None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="timing_none")
+            embeddings = _make_single_algorithm_embeddings()
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            assert result[0]["metadata"]["step_time"] is None
+
+    def test_single_algorithm_round_trip(self):
+        """Single-algorithm run should round-trip as a one-element list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cb = SaveTrajectory(save_dir=tmpdir, experiment_name="single_rt")
+            embeddings = _make_single_algorithm_embeddings(n_samples=50)
+            cb.on_latent_end(dataset=None, embeddings=embeddings)
+
+            result = load_trajectory(tmpdir)
+            assert len(result) == 1
+            assert result[0]["embeddings"].shape == (50, 2)
+            assert result[0]["metadata"]["algorithm"] == "PCA"
+            assert result[0]["scores"]["participation_ratio"] == pytest.approx(1.5)

--- a/tests/test_step_snapshots.py
+++ b/tests/test_step_snapshots.py
@@ -1,0 +1,292 @@
+"""Tests for step_snapshots captured by run_pipeline().
+
+Since run_pipeline() has heavy dependencies (Hydra, WandB, datamodules),
+we test the snapshot capture logic by mocking all infrastructure and
+verifying the snapshot dict structure.
+"""
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+def _make_pipeline_cfg():
+    """Minimal config that run_pipeline() accepts."""
+    return OmegaConf.create({
+        "pipeline": [
+            {
+                "name": "pca_step",
+                "overrides": {
+                    "algorithms": {"latent": {
+                        "_target_": "manylatents.algorithms.pca.PCALatent",
+                        "n_components": 10,
+                    }},
+                },
+            },
+            {
+                "name": "umap_step",
+                "overrides": {
+                    "algorithms": {"latent": {
+                        "_target_": "manylatents.algorithms.umap.UMAPLatent",
+                        "n_components": 2,
+                    }},
+                },
+            },
+        ],
+        "algorithms": {"latent": None, "lightning": None},
+        "callbacks": {"embedding": None},
+        "trainer": {"callbacks": {}},
+        "metrics": None,
+        "name": "test_snapshots",
+        "project": "test",
+        "seed": 42,
+        "debug": False,
+        "logger": None,
+    })
+
+
+class TestStepSnapshotLogic:
+    """Test the snapshot capture logic in isolation (no pipeline execution)."""
+
+    def test_snapshot_from_tensor(self):
+        """Snapshot of a torch.Tensor produces correct numpy array + metadata."""
+        tensor = torch.randn(80, 10)
+        snapshot_np = tensor.detach().cpu().numpy()
+
+        snap = {
+            "step_index": 0,
+            "step_name": "pca_step",
+            "algorithm": "PCA",
+            "output_shape": list(snapshot_np.shape),
+            "embedding": snapshot_np,
+        }
+
+        assert snap["step_index"] == 0
+        assert snap["step_name"] == "pca_step"
+        assert snap["algorithm"] == "PCA"
+        assert snap["output_shape"] == [80, 10]
+        assert snap["embedding"].shape == (80, 10)
+        assert isinstance(snap["embedding"], np.ndarray)
+
+    def test_snapshot_from_ndarray(self):
+        """Snapshot of a numpy array works correctly."""
+        arr = np.random.randn(60, 5)
+        snapshot_np = np.asarray(arr)
+
+        snap = {
+            "step_index": 1,
+            "step_name": "umap_step",
+            "algorithm": "UMAP",
+            "output_shape": list(snapshot_np.shape),
+            "embedding": snapshot_np,
+        }
+
+        assert snap["output_shape"] == [60, 5]
+        assert np.array_equal(snap["embedding"], arr)
+
+    def test_multi_step_snapshot_list(self):
+        """Building a list of snapshots preserves order and shapes."""
+        shapes = [(100, 50), (100, 10), (100, 2)]
+        names = ["pca", "tsne_init", "tsne_final"]
+        algos = ["PCA", "TSNE", "TSNE"]
+
+        step_snapshots = []
+        for i, (shape, name, algo) in enumerate(zip(shapes, names, algos)):
+            arr = np.random.randn(*shape)
+            step_snapshots.append({
+                "step_index": i,
+                "step_name": name,
+                "algorithm": algo,
+                "output_shape": list(arr.shape),
+                "embedding": arr,
+            })
+
+        assert len(step_snapshots) == 3
+        assert step_snapshots[0]["output_shape"] == [100, 50]
+        assert step_snapshots[1]["output_shape"] == [100, 10]
+        assert step_snapshots[2]["output_shape"] == [100, 2]
+
+    def test_snapshot_added_to_embeddings_dict(self):
+        """step_snapshots key in embeddings dict is backward-compatible."""
+        step_snapshots = [{
+            "step_index": 0,
+            "step_name": "pca",
+            "algorithm": "PCA",
+            "output_shape": [100, 2],
+            "embedding": np.random.randn(100, 2),
+        }]
+
+        embeddings = {
+            "embeddings": np.random.randn(100, 2),
+            "label": None,
+            "metadata": {"source": "pipeline"},
+            "step_snapshots": step_snapshots,
+        }
+
+        # Existing consumers access only known keys
+        assert "embeddings" in embeddings
+        assert "label" in embeddings
+        assert "metadata" in embeddings
+        # New key is present
+        assert "step_snapshots" in embeddings
+        assert len(embeddings["step_snapshots"]) == 1
+
+
+class TestRunPipelineSnapshots:
+    """Integration test: verify run_pipeline() actually includes step_snapshots."""
+
+    @patch("manylatents.experiment.wandb", None)
+    @patch("manylatents.experiment.evaluate")
+    @patch("manylatents.experiment.execute_step")
+    @patch("manylatents.experiment.instantiate_algorithm")
+    @patch("manylatents.experiment.instantiate_callbacks")
+    @patch("manylatents.experiment.instantiate_trainer")
+    @patch("manylatents.experiment.determine_data_source")
+    @patch("manylatents.experiment.instantiate_datamodule")
+    def test_run_pipeline_produces_step_snapshots(
+        self,
+        mock_inst_dm,
+        mock_det_source,
+        mock_inst_trainer,
+        mock_inst_cbs,
+        mock_inst_algo,
+        mock_exec_step,
+        mock_evaluate,
+    ):
+        n_samples = 80
+        cfg = _make_pipeline_cfg()
+
+        # Mock datamodule
+        mock_dm = MagicMock()
+        mock_dm.test_dataset.get_labels.return_value = None
+        train_loader = [
+            (torch.randn(40, 50),),
+            (torch.randn(40, 50),),
+        ]
+        test_loader = [
+            (torch.randn(40, 50),),
+            (torch.randn(40, 50),),
+        ]
+        mock_dm.train_dataloader.return_value = train_loader
+        mock_dm.test_dataloader.return_value = test_loader
+        mock_inst_dm.return_value = mock_dm
+
+        # Mock other infrastructure
+        mock_det_source.return_value = (0, "test_data")
+        mock_inst_trainer.return_value = MagicMock()
+        mock_inst_cbs.return_value = ([], [])
+
+        # Mock algorithms — need __name__ on the class
+        class FakePCA:
+            pass
+
+        class FakeUMAP:
+            pass
+
+        mock_inst_algo.side_effect = [FakePCA(), FakeUMAP()]
+
+        # Mock execute_step to return arrays of correct shape
+        pca_output = np.random.randn(n_samples, 10)
+        umap_output = np.random.randn(n_samples, 2)
+        mock_exec_step.side_effect = [pca_output, umap_output]
+
+        # Mock evaluate to return scores dict
+        mock_evaluate.return_value = {"participation_ratio": 1.5}
+
+        from manylatents.experiment import run_pipeline
+        result = run_pipeline(cfg)
+
+        assert "step_snapshots" in result
+        snaps = result["step_snapshots"]
+        assert len(snaps) == 2
+
+        # Step 0: PCA
+        s0 = snaps[0]
+        assert s0["step_index"] == 0
+        assert s0["step_name"] == "pca_step"
+        assert s0["algorithm"] == "FakePCA"
+        assert s0["output_shape"] == [n_samples, 10]
+        assert s0["embedding"].shape == (n_samples, 10)
+        assert isinstance(s0["step_time"], float)
+        assert s0["step_time"] >= 0
+
+        # Step 1: UMAP
+        s1 = snaps[1]
+        assert s1["step_index"] == 1
+        assert s1["step_name"] == "umap_step"
+        assert s1["algorithm"] == "FakeUMAP"
+        assert s1["output_shape"] == [n_samples, 2]
+        assert s1["embedding"].shape == (n_samples, 2)
+        assert isinstance(s1["step_time"], float)
+        assert s1["step_time"] >= 0
+
+        # Metadata timing
+        meta = result["metadata"]
+        assert isinstance(meta["step_times"], list)
+        assert len(meta["step_times"]) == 2
+        assert all(isinstance(t, float) and t >= 0 for t in meta["step_times"])
+        assert isinstance(meta["eval_time"], float) and meta["eval_time"] >= 0
+        assert isinstance(meta["total_time"], float) and meta["total_time"] >= 0
+
+    @patch("manylatents.experiment.wandb", None)
+    @patch("manylatents.experiment.evaluate")
+    @patch("manylatents.experiment.execute_step")
+    @patch("manylatents.experiment.instantiate_algorithm")
+    @patch("manylatents.experiment.instantiate_callbacks")
+    @patch("manylatents.experiment.instantiate_trainer")
+    @patch("manylatents.experiment.determine_data_source")
+    @patch("manylatents.experiment.instantiate_datamodule")
+    def test_snapshot_fields_complete(
+        self,
+        mock_inst_dm,
+        mock_det_source,
+        mock_inst_trainer,
+        mock_inst_cbs,
+        mock_inst_algo,
+        mock_exec_step,
+        mock_evaluate,
+    ):
+        """Every snapshot must contain all required fields."""
+        cfg = OmegaConf.create({
+            "pipeline": [{
+                "name": "only_step",
+                "overrides": {
+                    "algorithms": {"latent": {"_target_": "fake", "n_components": 5}},
+                },
+            }],
+            "algorithms": {"latent": None, "lightning": None},
+            "callbacks": {"embedding": None},
+            "trainer": {"callbacks": {}},
+            "metrics": None,
+            "name": "test_fields",
+            "project": "test",
+            "seed": 42,
+            "debug": False,
+            "logger": None,
+        })
+
+        mock_dm = MagicMock()
+        mock_dm.test_dataset.get_labels.return_value = None
+        mock_dm.train_dataloader.return_value = [(torch.randn(40, 20),)]
+        mock_dm.test_dataloader.return_value = [(torch.randn(40, 20),)]
+        mock_inst_dm.return_value = mock_dm
+
+        mock_det_source.return_value = (0, "test")
+        mock_inst_trainer.return_value = MagicMock()
+        mock_inst_cbs.return_value = ([], [])
+
+        class FakeAlgo:
+            pass
+
+        mock_inst_algo.return_value = FakeAlgo()
+        mock_exec_step.return_value = np.random.randn(40, 5)
+        mock_evaluate.return_value = {}
+
+        from manylatents.experiment import run_pipeline
+        result = run_pipeline(cfg)
+
+        snap = result["step_snapshots"][0]
+        required = {"step_index", "step_name", "algorithm", "output_shape", "embedding", "step_time"}
+        assert required.issubset(snap.keys())


### PR DESCRIPTION
## Summary

- Instrument `run_algorithm()` and `run_pipeline()` with `time.perf_counter()` so that `step_time`, `eval_time`, and `total_time` live in `embeddings["metadata"]` where they belong
- Add `SaveTrajectory` callback + `load_trajectory()` for persisting pipeline step snapshots (with `step_time` threaded through write/read round-trip)
- Eliminates the main reason `WorkflowResult` exists in the shop harness, unblocking the harness refactor (PR 3)

Closes #173

## Test plan

- [x] `tests/test_step_snapshots.py` — verifies `step_time` in snapshots, `step_times`/`eval_time`/`total_time` in pipeline metadata
- [x] `tests/callbacks/test_save_trajectory.py` — verifies `step_time` round-trips through SaveTrajectory → manifest → `load_trajectory`
- [x] All 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)