### PR TITLE
fix: handle torch tensors in compute_knn and _content_key

### DIFF
--- a/manylatents/utils/metrics.py
+++ b/manylatents/utils/metrics.py
@@ -11,9 +11,12 @@ from sklearn.neighbors import kneighbors_graph
 logger = logging.getLogger(__name__)
 
 
-def _content_key(data: np.ndarray) -> str:
+def _content_key(data) -> str:
     """O(1) content hash: shape + dtype + first/last row bytes."""
     import hashlib
+    import torch
+    if isinstance(data, torch.Tensor):
+        data = data.numpy()
     h = hashlib.sha256()
     h.update(f"{data.shape}{data.dtype}".encode())
     h.update(data[0].tobytes())
@@ -163,6 +166,11 @@ def compute_knn(
         (distances, indices) — both shape (n_samples, k+1) if include_self,
         or (n_samples, k) if not.
     """
+    # Ensure numpy (LatentModule.transform() returns tensors)
+    import torch
+    if isinstance(data, torch.Tensor):
+        data = data.numpy()
+
     # Check cache for a usable superset
     if cache is not None:
         key = _content_key(data)


### PR DESCRIPTION
## Summary
- `_content_key()` and `compute_knn()` crash with `AttributeError: 'Tensor' object has no attribute 'tobytes'` when receiving torch tensors
- `LatentModule.transform()` returns tensors, and `PrecomputedDataModule` stores data as tensors — both paths can reach `compute_knn` via `prewarm_cache` or direct metric calls
- Fix: convert tensors to numpy at entry to both functions

## Reproduction
```bash
.venv/bin/python3 -m manylatents.main --config-path=../../../../configs/manylatents \
  -m algorithms/latent=noop data=embryoid_body_pca \
  metrics/embedding=trustworthiness cluster=mila resources=cpu
```
Noop passes through PrecomputedDataModule tensors → trustworthiness calls `compute_knn` → `_content_key` → `.tobytes()` → crash.

## Test plan
- [x] `_content_key(torch.randn(100, 10))` returns valid hash
- [x] `compute_knn(torch.randn(100, 10), k=5)` returns numpy arrays
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)