### PR TITLE
feat: DSE input_space parameter for dataset-space computation

### DIFF
--- a/manylatents/experiment.py
+++ b/manylatents/experiment.py
@@ -197,9 +197,11 @@ def extract_k_requirements(metric_cfgs: Dict[str, DictConfig]) -> dict:
                     break
 
         if k_val is not None:
-            emb_k.add(k_val)
-            if target in _DATA_KNN_METRICS:
+            input_space = getattr(metric_cfg, "input_space", "embedding")
+            if input_space == "dataset" or target in _DATA_KNN_METRICS:
                 data_k.add(k_val)
+            if input_space != "dataset":
+                emb_k.add(k_val)
 
         if target in _SPECTRAL_METRICS:
             spectral = True

--- a/manylatents/metrics/diffusion_spectral_entropy.py
+++ b/manylatents/metrics/diffusion_spectral_entropy.py
@@ -112,7 +112,7 @@ def compute_diffusion_matrix_knn(
 
 @register_metric(
     aliases=["diffusion_spectral_entropy", "dse"],
-    default_params={"t": 3, "gaussian_kernel_sigma": 10, "output_mode": "entropy", "t_high": 100, "numerical_floor": 1e-6, "max_N": 10000, "random_seed": 0, "kernel": "knn", "k": 15, "alpha": 1.0},
+    default_params={"t": 3, "gaussian_kernel_sigma": 10, "output_mode": "entropy", "t_high": 100, "numerical_floor": 1e-6, "max_N": 10000, "random_seed": 0, "kernel": "knn", "k": 15, "alpha": 1.0, "input_space": "embedding"},
     description="Diffusion spectral entropy (eigenvalue count at diffusion time t)",
 )
 def DiffusionSpectralEntropy(
@@ -130,6 +130,7 @@ def DiffusionSpectralEntropy(
     kernel: str = "knn",
     k: int = 15,
     alpha: float = 1.0,
+    input_space: str = "embedding",
 ) -> float:
     """
     Diffusion spectral entropy and eigenvalue counting on embedding data.
@@ -153,8 +154,15 @@ def DiffusionSpectralEntropy(
         k: Neighborhood size for knn kernel (default 15)
         alpha: Density normalization (0=graph Laplacian, 0.5=Fokker-Planck, 1.0=Laplace-Beltrami)
     """
+    # Select input space
+    if input_space == "dataset":
+        if dataset is None or not hasattr(dataset, "data"):
+            raise ValueError("input_space='dataset' requires dataset with .data")
+        X = dataset.data
+    else:
+        X = embeddings
+
     # Subsample if too large
-    X = embeddings
     if max_N is not None and len(X) > max_N:
         random.seed(random_seed)
         rand_inds = np.array(random.sample(range(len(X)), k=max_N))


### PR DESCRIPTION
## Summary
- Add `input_space` parameter to `DiffusionSpectralEntropy`: `"embedding"` (default) or `"dataset"`
- Update `extract_k_requirements` to route kNN prewarming based on `input_space`

## Test plan
- [ ] CI passes
- [ ] Verify default behavior unchanged (input_space="embedding" uses embeddings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)