### PR TITLE
fix: use HTTPS for manylatents-omics git source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-manylatents-omics = { git = "ssh://git@github.com/latent-reasoning-works/manylatents-omics.git" }
+manylatents-omics = { git = "https://github.com/latent-reasoning-works/manylatents-omics.git" }
 shop = { path = "../shop", editable = true }
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- Change `[tool.uv.sources]` for manylatents-omics from SSH to HTTPS
- SSH fails in CI runners (no SSH keys), HTTPS works since the repo is now public

Fixes the CI failure introduced by #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)