### PR TITLE
feat: HFTextDataModule — unified hub + local shard loading

### DIFF
--- a/docs/probing.md
+++ b/docs/probing.md
@@ -103,7 +103,7 @@ callbacks:
 
 ## Probe Dataloader
 
-Probing uses a fixed subset of data for consistent comparisons across training. The `TextDataModule` provides this via `probe_dataloader()`:
+Probing uses a fixed subset of data for consistent comparisons across training. The `HFTextDataModule` provides this via `probe_dataloader()`:
 
 ```yaml
 data:

--- a/docs/superpowers/plans/2026-04-04-hf-text-datamodule.md
+++ b/docs/superpowers/plans/2026-04-04-hf-text-datamodule.md
@@ -1,0 +1,653 @@
+# HFTextDataModule Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename `TextDataModule` → `HFTextDataModule` and add local `.jsonl.zst` shard loading so the Pythia probe can use The Pile from the Mila cluster.
+
+**Architecture:** One class, two source modes. When `data_dir` is set, loads local files via `load_dataset("json", data_files=...)`. When `data_dir` is None, loads from HF Hub (existing behavior). Everything downstream of the HF Dataset dict is unchanged.
+
+**Tech Stack:** HuggingFace `datasets`, `transformers`, PyTorch Lightning, Hydra
+
+**Spec:** `docs/superpowers/specs/2026-04-04-hf-text-datamodule-design.md`
+
+---
+
+### Task 1: Rename TextDataModule → HFTextDataModule + backward compat alias
+
+**Files:**
+- Modify: `manylatents/data/text.py:13,32` (class renames)
+- Modify: `manylatents/lightning/callbacks/activation_tracker.py:142` (error message)
+- Modify: `docs/probing.md:106` (doc reference)
+
+- [ ] **Step 1: Rename the dataclass and class in text.py**
+
+In `manylatents/data/text.py`, make these changes:
+
+Line 13 — rename the dataclass:
+```python
+# old:
+class TextDataConfig:
+# new:
+class HFTextDataConfig:
+```
+
+Line 32 — rename the class:
+```python
+# old:
+class TextDataModule(LightningDataModule):
+# new:
+class HFTextDataModule(LightningDataModule):
+```
+
+Add backward-compat aliases at the very end of the file (after the `TokenizedDataset` class, around line 183):
+```python
+# Backward compatibility aliases
+TextDataModule = HFTextDataModule
+TextDataConfig = HFTextDataConfig
+```
+
+- [ ] **Step 2: Update error message in activation_tracker.py**
+
+In `manylatents/lightning/callbacks/activation_tracker.py` line 142, change:
+```python
+# old:
+                    "with probe_dataloader() (e.g., TextDataModule)."
+# new:
+                    "with probe_dataloader() (e.g., HFTextDataModule)."
+```
+
+- [ ] **Step 3: Update doc reference in probing.md**
+
+In `docs/probing.md` line 106, change:
+```markdown
+<!-- old: -->
+Probing uses a fixed subset of data for consistent comparisons across training. The `TextDataModule` provides this via `probe_dataloader()`:
+<!-- new: -->
+Probing uses a fixed subset of data for consistent comparisons across training. The `HFTextDataModule` provides this via `probe_dataloader()`:
+```
+
+- [ ] **Step 4: Run existing tests to verify nothing breaks**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_config_composition.py -x -q`
+
+Expected: All pass (wikitext.yaml still works because its `_target_` hasn't changed yet — that's Task 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manylatents/data/text.py manylatents/lightning/callbacks/activation_tracker.py docs/probing.md
+git commit -m "refactor: rename TextDataModule → HFTextDataModule with backward compat alias"
+```
+
+---
+
+### Task 2: Add local loading parameters and `_load_local()` / `_load_hub()` methods
+
+**Files:**
+- Modify: `manylatents/data/text.py` (HFTextDataModule `__init__`, new methods, `setup()` refactor)
+- Test: `tests/test_hf_text_datamodule.py` (new file)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_hf_text_datamodule.py`:
+
+```python
+"""Tests for HFTextDataModule local loading and scale controls."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from manylatents.data.text import HFTextDataModule
+
+
+class TestLocalLoading:
+    """Test _load_local() with mock jsonl files."""
+
+    @pytest.fixture
+    def mock_pile_dir(self, tmp_path):
+        """Create a mock Pile-like directory with jsonl files."""
+        train_dir = tmp_path / "train"
+        train_dir.mkdir()
+
+        # Create 3 small shard files
+        for i in range(3):
+            shard = train_dir / f"{i:02d}.jsonl"
+            lines = [
+                json.dumps({"text": f"Shard {i} example {j}.", "meta": {"pile_set_name": "test"}})
+                for j in range(20)
+            ]
+            shard.write_text("\n".join(lines))
+
+        # Create val file
+        val_file = tmp_path / "val.jsonl"
+        lines = [
+            json.dumps({"text": f"Val example {j}.", "meta": {"pile_set_name": "test"}})
+            for j in range(50)
+        ]
+        val_file.write_text("\n".join(lines))
+
+        return tmp_path
+
+    def test_load_local_basic(self, mock_pile_dir):
+        """Local mode loads train and val from jsonl files."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            seed=42,
+        )
+        dm.setup()
+        assert dm.train_dataset is not None
+        assert dm.val_dataset is not None
+        assert len(dm.train_dataset) > 0
+        assert len(dm.val_dataset) > 0
+
+    def test_num_shards(self, mock_pile_dir):
+        """num_shards=2 loads only 2 of 3 available shards."""
+        dm_all = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+        )
+        dm_all.setup()
+        n_all = len(dm_all.train_dataset)
+
+        dm_2 = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            num_shards=2,
+        )
+        dm_2.setup()
+        n_2 = len(dm_2.train_dataset)
+
+        assert n_2 < n_all
+
+    def test_max_train_samples(self, mock_pile_dir):
+        """max_train_samples caps the training set."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            max_train_samples=10,
+        )
+        dm.setup()
+        # 10 max, but some may be empty after filtering
+        assert len(dm.train_dataset) <= 10
+
+    def test_max_val_samples(self, mock_pile_dir):
+        """max_val_samples caps the validation set."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            max_val_samples=5,
+        )
+        dm.setup()
+        assert len(dm.val_dataset) <= 5
+
+    def test_text_column(self, mock_pile_dir):
+        """Custom text_column reads from the correct field."""
+        # Create a file with a different column name
+        custom_dir = mock_pile_dir / "custom"
+        custom_dir.mkdir()
+        train_dir = custom_dir / "train"
+        train_dir.mkdir()
+        shard = train_dir / "00.jsonl"
+        lines = [
+            json.dumps({"content": f"Custom col example {j}."})
+            for j in range(20)
+        ]
+        shard.write_text("\n".join(lines))
+        val = custom_dir / "val.jsonl"
+        lines = [
+            json.dumps({"content": f"Custom col val {j}."})
+            for j in range(10)
+        ]
+        val.write_text("\n".join(lines))
+
+        dm = HFTextDataModule(
+            data_dir=str(custom_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            text_column="content",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=5,
+        )
+        dm.setup()
+        assert len(dm.train_dataset) > 0
+        item = dm.train_dataset[0]
+        assert "input_ids" in item
+
+    def test_missing_train_files_raises(self, tmp_path):
+        """FileNotFoundError when no train files match the glob."""
+        (tmp_path / "val.jsonl").write_text(json.dumps({"text": "hi"}))
+        dm = HFTextDataModule(
+            data_dir=str(tmp_path),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+        )
+        with pytest.raises(FileNotFoundError, match="No train files"):
+            dm.setup()
+
+    def test_missing_val_files_raises(self, tmp_path):
+        """FileNotFoundError when no val files match the glob."""
+        train_dir = tmp_path / "train"
+        train_dir.mkdir()
+        (train_dir / "00.jsonl").write_text(json.dumps({"text": "hi"}))
+        dm = HFTextDataModule(
+            data_dir=str(tmp_path),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+        )
+        with pytest.raises(FileNotFoundError, match="No val files"):
+            dm.setup()
+
+
+class TestHubLoadingUnchanged:
+    """Verify hub loading still works after refactor."""
+
+    def test_default_hub_mode(self):
+        """data_dir=None means hub mode (existing behavior)."""
+        dm = HFTextDataModule(
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+        )
+        assert dm.data_dir is None
+        assert dm.dataset_name == "wikitext"
+
+    def test_backward_compat_alias(self):
+        """TextDataModule alias still works."""
+        from manylatents.data.text import TextDataModule
+        dm = TextDataModule(tokenizer_name="gpt2")
+        assert isinstance(dm, HFTextDataModule)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hf_text_datamodule.py -x -v 2>&1 | head -40`
+
+Expected: Failures — `HFTextDataModule.__init__()` does not accept `data_dir`, `num_shards`, etc.
+
+- [ ] **Step 3: Implement the changes in text.py**
+
+Replace the `__init__` method of `HFTextDataModule` (lines 39-63) with:
+
+```python
+    def __init__(
+        self,
+        # Source: hub (existing)
+        dataset_name: str | None = "wikitext",
+        dataset_config: str | None = "wikitext-2-raw-v1",
+        # Source: local
+        data_dir: str | None = None,
+        train_files: str = "train/*.jsonl.zst",
+        val_files: str = "val.jsonl.zst",
+        text_column: str = "text",
+        # Scale control
+        max_train_samples: int | None = None,
+        max_val_samples: int | None = None,
+        num_shards: int | None = None,
+        # Existing (unchanged)
+        tokenizer_name: str = "gpt2",
+        max_length: int = 128,
+        batch_size: int = 8,
+        num_workers: int = 0,
+        probe_n_samples: int = 512,
+        seed: int = 42,
+    ):
+        super().__init__()
+        self.dataset_name = dataset_name
+        self.dataset_config = dataset_config
+        self.data_dir = data_dir
+        self.train_files = train_files
+        self.val_files = val_files
+        self.text_column = text_column
+        self.max_train_samples = max_train_samples
+        self.max_val_samples = max_val_samples
+        self.num_shards = num_shards
+        self.tokenizer_name = tokenizer_name
+        self.max_length = max_length
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.probe_n_samples = probe_n_samples
+        self.seed = seed
+
+        self.tokenizer = None
+        self.train_dataset = None
+        self.val_dataset = None
+        self.probe_dataset = None
+```
+
+Add two private methods after `__init__` (before `prepare_data`):
+
+```python
+    def _load_hub(self):
+        """Load dataset from HuggingFace Hub."""
+        from datasets import load_dataset
+        return load_dataset(self.dataset_name, self.dataset_config)
+
+    def _load_local(self):
+        """Load dataset from local jsonl/jsonl.zst shards."""
+        from datasets import load_dataset
+        from glob import glob
+        from pathlib import Path
+
+        base = Path(self.data_dir)
+        train_paths = sorted(glob(str(base / self.train_files)))
+        val_paths = sorted(glob(str(base / self.val_files)))
+
+        if self.num_shards is not None:
+            train_paths = train_paths[:self.num_shards]
+
+        if not train_paths:
+            raise FileNotFoundError(f"No train files matching {base / self.train_files}")
+        if not val_paths:
+            raise FileNotFoundError(f"No val files matching {base / self.val_files}")
+
+        # Resolve symlinks (git-annex on Mila stores data behind symlinks)
+        train_paths = [str(Path(p).resolve()) for p in train_paths]
+        val_paths = [str(Path(p).resolve()) for p in val_paths]
+
+        return load_dataset("json", data_files={
+            "train": train_paths,
+            "validation": val_paths,
+        })
+```
+
+Replace `prepare_data` (lines 65-69):
+
+```python
+    def prepare_data(self):
+        """Download dataset and tokenizer (hub mode only)."""
+        if self.data_dir is None:
+            from datasets import load_dataset
+            load_dataset(self.dataset_name, self.dataset_config)
+        AutoTokenizer.from_pretrained(self.tokenizer_name)
+```
+
+Replace `setup` (lines 71-109):
+
+```python
+    def setup(self, stage: Optional[str] = None):
+        """Tokenize and prepare datasets."""
+        self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        if self.data_dir is not None:
+            dataset = self._load_local()
+        else:
+            dataset = self._load_hub()
+
+        # Apply sample caps
+        if self.max_train_samples is not None:
+            n = min(self.max_train_samples, len(dataset["train"]))
+            dataset["train"] = dataset["train"].select(range(n))
+        if self.max_val_samples is not None:
+            n = min(self.max_val_samples, len(dataset["validation"]))
+            dataset["validation"] = dataset["validation"].select(range(n))
+
+        text_column = self.text_column
+
+        def tokenize_fn(examples):
+            texts = [t for t in examples[text_column] if t.strip()]
+            if not texts:
+                return {"input_ids": [], "attention_mask": [], "labels": []}
+
+            tokenized = self.tokenizer(
+                texts,
+                truncation=True,
+                max_length=self.max_length,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            tokenized["labels"] = tokenized["input_ids"].clone()
+            return tokenized
+
+        self.train_dataset = TokenizedDataset(
+            dataset["train"], tokenize_fn, self.max_length, self.text_column
+        )
+        self.val_dataset = TokenizedDataset(
+            dataset["validation"], tokenize_fn, self.max_length, self.text_column
+        )
+
+        # Create fixed probe subset
+        generator = torch.Generator().manual_seed(self.seed)
+        n_probe = min(self.probe_n_samples, len(self.val_dataset))
+        indices = torch.randperm(len(self.val_dataset), generator=generator)[:n_probe]
+        self.probe_dataset = Subset(self.val_dataset, indices.tolist())
+```
+
+- [ ] **Step 4: Update `TokenizedDataset` to accept `text_column`**
+
+Replace the `TokenizedDataset.__init__` (lines 157-165) and `__getitem__` (lines 172-182):
+
+```python
+class TokenizedDataset(Dataset):
+    """Lazily tokenized dataset wrapper."""
+
+    def __init__(self, hf_dataset, tokenize_fn, max_length: int, text_column: str = "text"):
+        self.hf_dataset = hf_dataset
+        self.tokenize_fn = tokenize_fn
+        self.max_length = max_length
+        self.text_column = text_column
+        self._cache = {}
+
+        # Pre-filter to non-empty texts
+        self.valid_indices = [
+            i for i, ex in enumerate(hf_dataset)
+            if ex[self.text_column].strip()
+        ]
+
+    def __len__(self):
+        return len(self.valid_indices)
+
+    def __getitem__(self, idx):
+        real_idx = self.valid_indices[idx]
+        if real_idx not in self._cache:
+            example = self.hf_dataset[real_idx]
+            tokenized = self.tokenize_fn({self.text_column: [example[self.text_column]]})
+            self._cache[real_idx] = {
+                "input_ids": tokenized["input_ids"][0],
+                "attention_mask": tokenized["attention_mask"][0],
+                "labels": tokenized["labels"][0],
+            }
+        return self._cache[real_idx]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hf_text_datamodule.py -x -v`
+
+Expected: All pass.
+
+- [ ] **Step 6: Run existing tests for regression**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_config_composition.py -x -q`
+
+Expected: All pass (wikitext.yaml still targets `manylatents.data.text.TextDataModule` which is now an alias).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add manylatents/data/text.py tests/test_hf_text_datamodule.py
+git commit -m "feat: add local shard loading to HFTextDataModule (data_dir, num_shards, max_samples)"
+```
+
+---
+
+### Task 3: Config files — wikitext.yaml update, pile.yaml, experiment update
+
+**Files:**
+- Modify: `manylatents/configs/data/wikitext.yaml` (update `_target_`)
+- Create: `manylatents/configs/data/pile.yaml`
+- Modify: `manylatents/configs/experiment/representation_probe_pythia.yaml` (switch to pile data)
+
+- [ ] **Step 1: Update wikitext.yaml `_target_`**
+
+In `manylatents/configs/data/wikitext.yaml` line 5, change:
+```yaml
+# old:
+_target_: manylatents.data.text.TextDataModule
+# new:
+_target_: manylatents.data.text.HFTextDataModule
+```
+
+- [ ] **Step 2: Create pile.yaml**
+
+Create `manylatents/configs/data/pile.yaml`:
+```yaml
+# The Pile — Pythia's training data, loaded from Mila cluster local shards
+# Uses jsonl.zst format; num_shards/max_train_samples control scale
+_target_: manylatents.data.text.HFTextDataModule
+dataset_name: null
+dataset_config: null
+data_dir: "/network/datasets/pile"
+train_files: "train/*.jsonl.zst"
+val_files: "val.jsonl.zst"
+text_column: "text"
+tokenizer_name: "EleutherAI/pythia-70m"
+max_length: 128
+batch_size: 8
+num_workers: 0
+probe_n_samples: 512
+num_shards: 1
+max_train_samples: 50000
+seed: ${seed}
+```
+
+- [ ] **Step 3: Update representation_probe_pythia.yaml**
+
+Replace the full content of `manylatents/configs/experiment/representation_probe_pythia.yaml`:
+
+```yaml
+# @package _global_
+#
+# End-to-end experiment for representation probing on Pythia models.
+# Uses The Pile (Pythia's training data) from Mila cluster local shards.
+#
+# Usage:
+#   python -m manylatents.main experiment=representation_probe_pythia
+#   python -m manylatents.main experiment=representation_probe_pythia \
+#       algorithms.lightning.config.model_name_or_path=/network/weights/pythia/pythia-410m \
+#       data.tokenizer_name=EleutherAI/pythia-410m
+#
+name: representation_probe_pythia
+
+defaults:
+  - override /data: pile
+  - override /algorithms/lightning: hf_trainer
+  - override /trainer: default
+  - override /callbacks/trainer: probe_pythia
+  - _self_
+
+seed: 42
+project: representation_probe
+debug: false
+
+# --- Data Configuration ---
+data:
+  probe_n_samples: 512
+
+# --- Model Configuration ---
+# Weights are local on Mila cluster; tokenizer loaded from HuggingFace hub
+algorithms:
+  lightning:
+    config:
+      model_name_or_path: "/network/weights/pythia/pythia-70m/step143000"
+      output_hidden_states: true
+      learning_rate: 2e-5
+      weight_decay: 0.01
+      warmup_steps: 100
+
+# --- Trainer Configuration ---
+trainer:
+  max_epochs: 3
+  precision: bf16-mixed
+  gradient_clip_val: 1.0
+  accumulate_grad_batches: 4
+  val_check_interval: 0.5
+  log_every_n_steps: 50
+```
+
+- [ ] **Step 4: Run config composition tests**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_config_composition.py -x -q`
+
+Expected: All pass, including new `pile` config.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manylatents/configs/data/wikitext.yaml manylatents/configs/data/pile.yaml manylatents/configs/experiment/representation_probe_pythia.yaml
+git commit -m "config: add pile.yaml data config, update pythia experiment to use Pile"
+```
+
+---
+
+### Task 4: Final verification
+
+**Files:** None (test-only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/ -x -q`
+
+Expected: All pass.
+
+- [ ] **Step 2: Run callback tests**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest manylatents/callbacks/tests/ -x -q`
+
+Expected: All pass.
+
+- [ ] **Step 3: Run new HFTextDataModule tests specifically**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hf_text_datamodule.py -v`
+
+Expected: All 9 tests pass:
+- `test_load_local_basic` — PASS
+- `test_num_shards` — PASS
+- `test_max_train_samples` — PASS
+- `test_max_val_samples` — PASS
+- `test_text_column` — PASS
+- `test_missing_train_files_raises` — PASS
+- `test_missing_val_files_raises` — PASS
+- `test_default_hub_mode` — PASS
+- `test_backward_compat_alias` — PASS
+
+- [ ] **Step 4: Verify config composition includes pile**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_config_composition.py -k pile -v`
+
+Expected: pile config resolves without errors.

--- a/docs/superpowers/plans/2026-04-04-interpretability-experiment-infra.md
+++ b/docs/superpowers/plans/2026-04-04-interpretability-experiment-infra.md
@@ -1,0 +1,532 @@
+# Interpretability Experiment Infrastructure — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose UMAP `negative_sample_rate` for causal mechanism experiments and wire Pythia hidden-state probing infrastructure.
+
+**Architecture:** Two independent changes. (1) Add one parameter to `UMAPModule`, pass it to sklearn UMAP. (2) Add `output_hidden_states` to `HFTrainerConfig`, create Pythia-specific probe and experiment configs.
+
+**Tech Stack:** umap-learn, transformers (HF), PyTorch Lightning, Hydra
+
+**Spec:** `docs/superpowers/specs/2026-04-04-interpretability-experiment-infra-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `manylatents/algorithms/latent/umap.py` | Add `negative_sample_rate` param, pass to sklearn |
+| Modify | `manylatents/configs/algorithms/latent/umap.yaml` | Expose param in config |
+| Modify | `tests/test_umap_backend.py` | Test negative_sample_rate reaches sklearn |
+| Modify | `manylatents/lightning/hf_trainer.py` | Add `output_hidden_states` to config + forward |
+| Modify | `manylatents/configs/algorithms/lightning/hf_trainer.yaml` | Expose param in config |
+| Create | `manylatents/configs/callbacks/trainer/probe_pythia.yaml` | Pythia layer paths for probe callback |
+| Create | `manylatents/configs/experiment/representation_probe_pythia.yaml` | End-to-end Pythia probe experiment |
+| Modify | `manylatents/lightning/tests/test_hf_trainer.py` | Test output_hidden_states passthrough |
+
+---
+
+### Task 1: UMAP `negative_sample_rate` — Test + Implementation
+
+**Files:**
+- Modify: `tests/test_umap_backend.py`
+- Modify: `manylatents/algorithms/latent/umap.py:13-67`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the end of `tests/test_umap_backend.py`:
+
+```python
+def test_umap_negative_sample_rate_affects_embedding():
+    """negative_sample_rate should reach sklearn UMAP and change the embedding."""
+    from manylatents.algorithms.latent.umap import UMAPModule
+
+    x = torch.randn(80, 10, generator=torch.Generator().manual_seed(0))
+
+    m1 = UMAPModule(
+        n_components=2, random_state=42, n_neighbors=10,
+        n_epochs=50, negative_sample_rate=1,
+    )
+    emb1 = m1.fit_transform(x)
+
+    m2 = UMAPModule(
+        n_components=2, random_state=42, n_neighbors=10,
+        n_epochs=50, negative_sample_rate=10,
+    )
+    emb2 = m2.fit_transform(x)
+
+    # Same seed, same data, different negative_sample_rate -> different embeddings
+    assert emb1.shape == emb2.shape == (80, 2)
+    assert not np.allclose(emb1, emb2, atol=1e-3), (
+        "Embeddings should differ when negative_sample_rate changes"
+    )
+
+
+def test_umap_negative_sample_rate_none_uses_default():
+    """negative_sample_rate=None should not change default sklearn behavior."""
+    from manylatents.algorithms.latent.umap import UMAPModule
+
+    m = UMAPModule(n_components=2, random_state=42, n_neighbors=5, n_epochs=10)
+    assert m.negative_sample_rate is None
+    # sklearn default is 5 — verify it's not overridden
+    from umap import UMAP as SklearnUMAP
+    assert m.model.negative_sample_rate == SklearnUMAP().negative_sample_rate
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_umap_backend.py::test_umap_negative_sample_rate_affects_embedding -v`
+
+Expected: FAIL — `TypeError: UMAPModule.__init__() got an unexpected keyword argument 'negative_sample_rate'`
+
+- [ ] **Step 3: Add `negative_sample_rate` to UMAPModule**
+
+In `manylatents/algorithms/latent/umap.py`, add the parameter to `__init__` and pass it through in `_create_model()`.
+
+In `__init__`, add `negative_sample_rate: int | None = None` after `fit_fraction` (line 22), and store it:
+
+Replace the `__init__` parameter list and body (lines 14–43):
+
+```python
+class UMAPModule(LatentModule):
+    def __init__(
+        self,
+        n_components: int = 2,
+        random_state: Optional[int] = 42,
+        n_neighbors: int = 15,
+        min_dist: float = 0.5,
+        metric: str = 'euclidean',
+        n_epochs: Optional[int] = 200,
+        learning_rate: float = 1.0,
+        fit_fraction: float = 1.0,
+        negative_sample_rate: int | None = None,
+        backend: str | None = None,
+        device: str | None = None,
+        neighborhood_size: Optional[int] = None,
+        **kwargs
+    ):
+        super().__init__(
+            n_components=n_components, init_seed=random_state,
+            backend=backend, device=device,
+            neighborhood_size=neighborhood_size, **kwargs,
+        )
+        self.n_neighbors = neighborhood_size if neighborhood_size is not None else n_neighbors
+        self.min_dist = min_dist
+        self.metric = metric
+        self.n_epochs = n_epochs
+        self.learning_rate = learning_rate
+        self.fit_fraction = fit_fraction
+        self.negative_sample_rate = negative_sample_rate
+        self.random_state = random_state
+
+        self._resolved_backend = resolve_backend(backend)
+        self.model = self._create_model()
+```
+
+In `_create_model()`, pass `negative_sample_rate` to the sklearn branch only. Replace the else branch (lines 56–67):
+
+```python
+    def _create_model(self):
+        if self._resolved_backend == "torchdr":
+            from torchdr import UMAP
+
+            return UMAP(
+                n_components=self.n_components,
+                n_neighbors=self.n_neighbors,
+                min_dist=self.min_dist,
+                device=resolve_device(self.device),
+                random_state=self.random_state,
+            )
+        else:
+            from umap import UMAP
+
+            kwargs = {}
+            if self.negative_sample_rate is not None:
+                kwargs["negative_sample_rate"] = self.negative_sample_rate
+            return UMAP(
+                n_components=self.n_components,
+                random_state=self.random_state,
+                n_neighbors=self.n_neighbors,
+                min_dist=self.min_dist,
+                metric=self.metric,
+                n_epochs=self.n_epochs,
+                learning_rate=self.learning_rate,
+                **kwargs,
+            )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_umap_backend.py -v`
+
+Expected: ALL PASS (including existing tests — no regressions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_umap_backend.py manylatents/algorithms/latent/umap.py
+git commit -m "feat: expose negative_sample_rate in UMAPModule for sklearn backend"
+```
+
+---
+
+### Task 2: UMAP `negative_sample_rate` — Config
+
+**Files:**
+- Modify: `manylatents/configs/algorithms/latent/umap.yaml`
+
+- [ ] **Step 1: Add the parameter to the Hydra config**
+
+Add `negative_sample_rate: null` to `manylatents/configs/algorithms/latent/umap.yaml` after `fit_fraction`:
+
+```yaml
+_target_: manylatents.algorithms.latent.umap.UMAPModule
+n_components: 2
+random_state: ${seed}
+n_neighbors: 15
+min_dist: 0.5
+n_epochs: 500
+metric: 'euclidean'
+learning_rate: 1.0
+fit_fraction: 1.0
+negative_sample_rate: null
+neighborhood_size: ${neighborhood_size}
+backend: null
+device: null
+```
+
+- [ ] **Step 2: Verify Hydra config composes correctly**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hydra_configs.py -v -k "umap"`
+
+Expected: PASS — the config group test should still compose without errors. If no Hydra config test exists for umap specifically, run the full config test suite:
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hydra_configs.py -v`
+
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manylatents/configs/algorithms/latent/umap.yaml
+git commit -m "config: add negative_sample_rate to umap.yaml (default null)"
+```
+
+---
+
+### Task 3: HFTrainerModule `output_hidden_states` — Test + Implementation
+
+**Files:**
+- Modify: `manylatents/lightning/tests/test_hf_trainer.py`
+- Modify: `manylatents/lightning/hf_trainer.py:17-85`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the end of `manylatents/lightning/tests/test_hf_trainer.py`:
+
+```python
+def test_hf_trainer_config_output_hidden_states_default():
+    """output_hidden_states should default to False."""
+    config = HFTrainerConfig(model_name_or_path="gpt2")
+    assert config.output_hidden_states is False
+
+
+@pytest.mark.slow
+def test_hf_trainer_output_hidden_states():
+    """forward() with output_hidden_states=True returns hidden state tuple."""
+    config = HFTrainerConfig(
+        model_name_or_path="sshleifer/tiny-gpt2",
+        output_hidden_states=True,
+    )
+    module = HFTrainerModule(config)
+    module.configure_model()
+
+    tokenizer = module.tokenizer
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    batch = tokenizer(
+        ["Hello world", "Test input"],
+        return_tensors="pt",
+        padding=True,
+        max_length=32,
+    )
+
+    module.eval()
+    with torch.no_grad():
+        outputs = module(**batch)
+
+    assert outputs.hidden_states is not None
+    # hidden_states is a tuple of (n_layers + 1) tensors (embedding + each layer)
+    n_layers = module.network.config.num_hidden_layers
+    assert len(outputs.hidden_states) == n_layers + 1
+    # Each tensor: (batch, seq_len, hidden_dim)
+    assert outputs.hidden_states[0].shape[0] == 2  # batch_size
+
+
+@pytest.mark.slow
+def test_hf_trainer_output_hidden_states_disabled():
+    """forward() with output_hidden_states=False returns None for hidden_states."""
+    config = HFTrainerConfig(
+        model_name_or_path="sshleifer/tiny-gpt2",
+        output_hidden_states=False,
+    )
+    module = HFTrainerModule(config)
+    module.configure_model()
+
+    tokenizer = module.tokenizer
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    batch = tokenizer(
+        ["Hello world"],
+        return_tensors="pt",
+        padding=True,
+        max_length=32,
+    )
+
+    module.eval()
+    with torch.no_grad():
+        outputs = module(**batch)
+
+    assert outputs.hidden_states is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest manylatents/lightning/tests/test_hf_trainer.py::test_hf_trainer_config_output_hidden_states_default -v`
+
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'output_hidden_states'`
+
+- [ ] **Step 3: Add `output_hidden_states` to HFTrainerConfig and forward()**
+
+In `manylatents/lightning/hf_trainer.py`, add the field to `HFTrainerConfig` (after `attn_implementation`, before `device_map`):
+
+```python
+@dataclass
+class HFTrainerConfig:
+    """Configuration for HFTrainerModule.
+
+    Attributes:
+        model_name_or_path: HuggingFace model identifier or local path
+        learning_rate: Learning rate for AdamW
+        weight_decay: Weight decay for AdamW
+        warmup_steps: Number of warmup steps for scheduler
+        adam_epsilon: Epsilon for AdamW
+        torch_dtype: Optional dtype for model (e.g., torch.bfloat16)
+        trust_remote_code: Whether to trust remote code for model loading
+        attn_implementation: Attention implementation (e.g., "flash_attention_2")
+        output_hidden_states: Whether to return hidden states from all layers
+        device_map: Device placement strategy (e.g., "auto"). None lets
+            Lightning/FSDP manage placement (existing behavior).
+    """
+    model_name_or_path: str
+    learning_rate: float = 2e-5
+    weight_decay: float = 0.0
+    warmup_steps: int = 0
+    adam_epsilon: float = 1e-8
+    torch_dtype: Optional[torch.dtype] = None
+    trust_remote_code: bool = False
+    attn_implementation: Optional[str] = None
+    output_hidden_states: bool = False
+    device_map: Optional[str] = None
+```
+
+Update `forward()` in `HFTrainerModule`:
+
+```python
+    def forward(self, **inputs) -> CausalLMOutput:
+        """Forward pass through the model."""
+        return self.network(
+            **inputs,
+            output_hidden_states=self.config.output_hidden_states,
+        )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest manylatents/lightning/tests/test_hf_trainer.py -v`
+
+Expected: ALL PASS (including all existing tests — no regressions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manylatents/lightning/hf_trainer.py manylatents/lightning/tests/test_hf_trainer.py
+git commit -m "feat: add output_hidden_states to HFTrainerConfig for multi-layer extraction"
+```
+
+---
+
+### Task 4: HF Trainer Config YAML + Pythia Probe Config
+
+**Files:**
+- Modify: `manylatents/configs/algorithms/lightning/hf_trainer.yaml`
+- Create: `manylatents/configs/callbacks/trainer/probe_pythia.yaml`
+
+- [ ] **Step 1: Add `output_hidden_states` to hf_trainer.yaml**
+
+Update `manylatents/configs/algorithms/lightning/hf_trainer.yaml`:
+
+```yaml
+# manylatents/configs/algorithms/lightning/hf_trainer.yaml
+# HuggingFace causal LM trainer configuration
+_target_: manylatents.lightning.hf_trainer.HFTrainerModule
+
+config:
+  _target_: manylatents.lightning.hf_trainer.HFTrainerConfig
+  model_name_or_path: "gpt2"
+  learning_rate: 2e-5
+  weight_decay: 0.0
+  warmup_steps: 100
+  adam_epsilon: 1e-8
+  trust_remote_code: false
+  output_hidden_states: false
+  # Optional: torch_dtype, attn_implementation
+```
+
+- [ ] **Step 2: Create Pythia probe callback config**
+
+Create `manylatents/configs/callbacks/trainer/probe_pythia.yaml`:
+
+```yaml
+# Pythia representation probe callback configuration
+# Layer path uses gpt_neox.layers[] (GPT-NeoX architecture)
+# Override layer_specs via CLI for multi-layer or specific-layer extraction
+probe:
+  _target_: manylatents.lightning.callbacks.activation_tracker.ActivationTrajectoryCallback
+  layer_specs:
+    - _target_: manylatents.lightning.hooks.LayerSpec
+      path: "gpt_neox.layers[-1]"
+      extraction_point: "output"
+      reduce: "mean"
+  trigger:
+    _target_: manylatents.lightning.callbacks.activation_tracker.ProbeTrigger
+    every_n_steps: 500
+    on_checkpoint: true
+    on_validation_end: true
+  gauge:
+    _target_: manylatents.callbacks.diffusion_operator.DiffusionGauge
+    knn: 15
+    alpha: 1.0
+    symmetric: false
+  log_to_wandb: true
+```
+
+- [ ] **Step 3: Verify Hydra config composition**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hydra_configs.py -v`
+
+Expected: ALL PASS — new config files should be picked up by the composition test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add manylatents/configs/algorithms/lightning/hf_trainer.yaml manylatents/configs/callbacks/trainer/probe_pythia.yaml
+git commit -m "config: add output_hidden_states to hf_trainer, add probe_pythia callback"
+```
+
+---
+
+### Task 5: Pythia Experiment Config
+
+**Files:**
+- Create: `manylatents/configs/experiment/representation_probe_pythia.yaml`
+
+- [ ] **Step 1: Create the experiment config**
+
+Create `manylatents/configs/experiment/representation_probe_pythia.yaml`:
+
+```yaml
+# @package _global_
+#
+# End-to-end experiment for representation probing on Pythia models.
+#
+# Usage:
+#   python -m manylatents.main experiment=representation_probe_pythia
+#   python -m manylatents.main experiment=representation_probe_pythia \
+#       algorithms.lightning.config.model_name_or_path=/network/weights/pythia/pythia-410m \
+#       data.tokenizer_name=EleutherAI/pythia-410m
+#
+name: representation_probe_pythia
+
+defaults:
+  - override /data: wikitext
+  - override /algorithms/lightning: hf_trainer
+  - override /trainer: default
+  - override /callbacks/trainer: probe_pythia
+  - _self_
+
+seed: 42
+project: representation_probe
+debug: false
+
+# --- Data Configuration ---
+data:
+  tokenizer_name: "EleutherAI/pythia-70m"
+  max_length: 128
+  batch_size: 8
+  probe_n_samples: 512
+
+# --- Model Configuration ---
+# Weights are local on Mila cluster; tokenizer loaded from HuggingFace hub
+algorithms:
+  lightning:
+    config:
+      model_name_or_path: "/network/weights/pythia/pythia-70m"
+      output_hidden_states: true
+      learning_rate: 2e-5
+      weight_decay: 0.01
+      warmup_steps: 100
+
+# --- Trainer Configuration ---
+trainer:
+  max_epochs: 3
+  precision: bf16-mixed
+  gradient_clip_val: 1.0
+  accumulate_grad_batches: 4
+  val_check_interval: 0.5
+  log_every_n_steps: 50
+```
+
+- [ ] **Step 2: Verify Hydra config composition**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hydra_configs.py -v -k "representation_probe_pythia or experiment"`
+
+If no experiment-specific Hydra test exists, verify manually:
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run python -c "from hydra import compose, initialize_config_dir; initialize_config_dir(config_dir='manylatents/configs', version_base=None); cfg = compose(config_name='config', overrides=['experiment=representation_probe_pythia']); print(cfg.algorithms.lightning.config.model_name_or_path)"`
+
+Expected: `/network/weights/pythia/pythia-70m`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manylatents/configs/experiment/representation_probe_pythia.yaml
+git commit -m "config: add representation_probe_pythia experiment config"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:** None (test-only)
+
+- [ ] **Step 1: Run the full test suite to check for regressions**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/ -x -q && uv run pytest manylatents/callbacks/tests/ -x -q`
+
+Expected: ALL PASS
+
+- [ ] **Step 2: Run slow HF tests specifically**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest manylatents/lightning/tests/test_hf_trainer.py -v -m slow`
+
+Expected: ALL PASS (including the new `output_hidden_states` tests)
+
+- [ ] **Step 3: Run the Hydra config composition tests**
+
+Run: `cd /network/scratch/c/cesar.valdez/lrw/manylatents && uv run pytest tests/test_hydra_configs.py -v`
+
+Expected: ALL PASS (all config groups compose, including new `probe_pythia` and `representation_probe_pythia`)

--- a/docs/superpowers/specs/2026-04-04-hf-text-datamodule-design.md
+++ b/docs/superpowers/specs/2026-04-04-hf-text-datamodule-design.md
@@ -1,0 +1,230 @@
+# HFTextDataModule: Unified Hub + Local Text Data Loading
+
+**Date:** 2026-04-04
+**Status:** Design approved
+**Scope:** manylatents core (public repo)
+
+## Problem
+
+`TextDataModule` loads text exclusively from HuggingFace Hub via `load_dataset(name, config)`. The Pythia representation probe needs The Pile — Pythia's actual training data — which sits on the Mila cluster as local `.jsonl.zst` shards. Using WikiText (the current default) means probing on OOD text, confounding interpretability results.
+
+The Pile on Mila:
+- **Train:** 30 shards (`train/00.jsonl.zst` ... `train/29.jsonl.zst`), ~14 GB each, 427 GB total
+- **Val:** `val.jsonl.zst`, 214,670 examples, ~450 MB compressed
+- **Format:** `{"text": "...", "meta": {"pile_set_name": "..."}}` — same `text` key as WikiText
+- **Storage:** git-annex symlinks (resolved, readable)
+
+## Design
+
+### Rename: `TextDataModule` → `HFTextDataModule`
+
+The current name is misleading. The module is HF-ecosystem end-to-end: HF `datasets` for loading, HF `AutoTokenizer` for tokenization, HF-format output (`input_ids`, `attention_mask`, `labels`). The rename makes this explicit.
+
+File rename: `manylatents/data/text.py` stays (module path unchanged), class name changes. Config `_target_` paths update accordingly.
+
+### Two source modes, one class
+
+The tokenization → batching → probe subset pipeline is identical regardless of where the raw text comes from. Only the `load_dataset()` call differs:
+
+```python
+# Hub mode (current behavior):
+dataset = load_dataset(self.dataset_name, self.dataset_config)
+
+# Local mode (new):
+dataset = load_dataset("json", data_files={"train": [...], "validation": [...]})
+```
+
+**Routing:** When `data_dir` is set, use local mode. When `data_dir` is None, use hub mode (existing behavior).
+
+### New parameters
+
+```python
+class HFTextDataModule(LightningDataModule):
+    def __init__(
+        self,
+        # --- Source: hub (existing) ---
+        dataset_name: str | None = "wikitext",
+        dataset_config: str | None = "wikitext-2-raw-v1",
+        # --- Source: local (new) ---
+        data_dir: str | None = None,
+        train_files: str = "train/*.jsonl.zst",
+        val_files: str = "val.jsonl.zst",
+        text_column: str = "text",
+        # --- Scale control (new) ---
+        max_train_samples: int | None = None,
+        max_val_samples: int | None = None,
+        num_shards: int | None = None,
+        # --- Existing (unchanged) ---
+        tokenizer_name: str = "gpt2",
+        max_length: int = 128,
+        batch_size: int = 8,
+        num_workers: int = 0,
+        probe_n_samples: int = 512,
+        seed: int = 42,
+    ):
+```
+
+| Parameter | Purpose | Default |
+|-----------|---------|---------|
+| `data_dir` | Base directory for local shards. When set, switches to local mode. | `None` (hub mode) |
+| `train_files` | Glob pattern relative to `data_dir` for training data | `"train/*.jsonl.zst"` |
+| `val_files` | Glob pattern relative to `data_dir` for validation data | `"val.jsonl.zst"` |
+| `text_column` | Column name containing raw text | `"text"` |
+| `max_train_samples` | Cap on training examples (applied after loading) | `None` (use all) |
+| `max_val_samples` | Cap on validation examples | `None` (use all) |
+| `num_shards` | Load only first N train shards (for scale control) | `None` (use all) |
+
+### Loading logic in `setup()`
+
+```python
+def setup(self, stage=None):
+    self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+    if self.tokenizer.pad_token is None:
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+    if self.data_dir is not None:
+        dataset = self._load_local()
+    else:
+        dataset = self._load_hub()
+
+    # Apply sample caps
+    if self.max_train_samples:
+        dataset["train"] = dataset["train"].select(range(
+            min(self.max_train_samples, len(dataset["train"]))
+        ))
+    if self.max_val_samples:
+        dataset["validation"] = dataset["validation"].select(range(
+            min(self.max_val_samples, len(dataset["validation"]))
+        ))
+
+    # Rest unchanged: tokenize, wrap in TokenizedDataset, create probe subset
+```
+
+```python
+def _load_hub(self):
+    """Load from HuggingFace Hub."""
+    from datasets import load_dataset
+    return load_dataset(self.dataset_name, self.dataset_config)
+
+def _load_local(self):
+    """Load from local jsonl/jsonl.zst shards."""
+    from datasets import load_dataset
+    from glob import glob
+    from pathlib import Path
+
+    base = Path(self.data_dir)
+    train_paths = sorted(glob(str(base / self.train_files)))
+    val_paths = sorted(glob(str(base / self.val_files)))
+
+    if self.num_shards is not None:
+        train_paths = train_paths[:self.num_shards]
+
+    if not train_paths:
+        raise FileNotFoundError(f"No train files matching {base / self.train_files}")
+    if not val_paths:
+        raise FileNotFoundError(f"No val files matching {base / self.val_files}")
+
+    # Resolve symlinks (git-annex on Mila stores data behind symlinks)
+    train_paths = [str(Path(p).resolve()) for p in train_paths]
+    val_paths = [str(Path(p).resolve()) for p in val_paths]
+
+    return load_dataset("json", data_files={
+        "train": train_paths,
+        "validation": val_paths,
+    })
+```
+
+### `text_column` handling
+
+The Pile and WikiText both use `"text"` as the column name, but other local datasets might not. `TokenizedDataset` currently hardcodes `example["text"]`. The fix is to pass `text_column` through:
+
+```python
+class TokenizedDataset(Dataset):
+    def __init__(self, hf_dataset, tokenize_fn, max_length, text_column="text"):
+        self.text_column = text_column
+        # valid_indices filter uses self.text_column instead of hardcoded "text"
+```
+
+### Config files
+
+**`data/wikitext.yaml`** — updated `_target_`, otherwise unchanged:
+```yaml
+_target_: manylatents.data.text.HFTextDataModule
+dataset_name: "wikitext"
+dataset_config: "wikitext-2-raw-v1"
+tokenizer_name: "gpt2"
+max_length: 128
+batch_size: 8
+num_workers: 0
+probe_n_samples: 512
+seed: ${seed}
+```
+
+**`data/pile.yaml`** — new:
+```yaml
+_target_: manylatents.data.text.HFTextDataModule
+dataset_name: null
+dataset_config: null
+data_dir: "/network/datasets/pile"
+train_files: "train/*.jsonl.zst"
+val_files: "val.jsonl.zst"
+text_column: "text"
+tokenizer_name: "EleutherAI/pythia-70m"
+max_length: 128
+batch_size: 8
+num_workers: 0
+probe_n_samples: 512
+num_shards: 1
+max_train_samples: 50000
+seed: ${seed}
+```
+
+**`experiment/representation_probe_pythia.yaml`** — update data override:
+```yaml
+defaults:
+  - override /data: pile    # was: wikitext
+```
+Remove `data.tokenizer_name` override (now in pile.yaml). Keep `data.max_length`, `data.batch_size`, `data.probe_n_samples` overrides if the experiment needs different values.
+
+### Scale guidance
+
+| Use case | `num_shards` | `max_train_samples` | ~Size |
+|----------|-------------|-------------------|-------|
+| Dev/smoke test | 1 | 1000 | <1 MB |
+| Probing experiment | 1 | 50000 | ~25 MB |
+| Fine-tune (small) | 3 | null | ~42 GB |
+| Full training | null | null | ~427 GB |
+
+### What does NOT change
+
+- `TokenizedDataset` class — same interface (HF datasets from `load_dataset("json")` has identical row access)
+- `_collate_fn` — unchanged
+- `probe_dataloader()` — unchanged
+- `prepare_data()` — only called in hub mode (local files already exist)
+- No new base class, no subclass hierarchy — follows existing flat DataModule pattern
+
+### Backward compatibility
+
+- `TextDataModule` name becomes `HFTextDataModule`. Add a deprecation alias:
+  ```python
+  TextDataModule = HFTextDataModule  # backward compat
+  ```
+- `TextDataConfig` dataclass is unused externally (not referenced in configs) — rename to `HFTextDataConfig` or remove.
+- The activation_tracker.py reference to "TextDataModule" in an error message gets updated.
+
+## Testing
+
+1. **Config unit test:** `HFTextDataModule` instantiable from both `wikitext.yaml` and `pile.yaml`
+2. **Hub loading test:** existing wikitext tests still pass (regression)
+3. **Local loading test:** mock local jsonl files, verify `_load_local()` returns correct HF Dataset structure
+4. **`num_shards` test:** with 3 mock shard files, `num_shards=2` loads exactly 2
+5. **`max_train_samples` test:** verify truncation
+6. **`text_column` test:** dataset with non-"text" column name loads correctly
+7. **Symlink resolution test:** verify `Path.resolve()` is called on local paths
+8. **Pile smoke test (slow, cluster-only):** load 100 samples from real Pile val, tokenize, verify shapes
+
+## Not in scope
+
+- Streaming/IterableDataset support — `load_dataset("json")` uses memory-mapped Arrow, efficient enough for single-shard probing
+- Filtering by `pile_set_name` — can be added later via a `filter_fn` param if needed
+- New base class for DataModules — existing flat pattern works

--- a/docs/superpowers/specs/2026-04-04-interpretability-experiment-infra-design.md
+++ b/docs/superpowers/specs/2026-04-04-interpretability-experiment-infra-design.md
@@ -1,0 +1,223 @@
+# Interpretability Experiment Infrastructure
+
+**Date:** 2026-04-04
+**Status:** Draft
+**Scope:** manylatents core changes to enable two experiments
+
+## Context
+
+Two planned experiments require small infrastructure additions to manylatents:
+
+1. **Negative sample rate experiment** — Run UMAP with `negative_sample_rate in {1, 3, 5, 10}`, k-sweep at each. Tests whether the embedding quality cliff position shifts proportionally with negative sample rate, which would identify attraction-repulsion balance as the causal mechanism behind the threshold.
+
+2. **Pythia hidden state experiment** — Extract intermediate layer representations from Pythia language models, run full diagnostic + k-sweep. Tests whether the cliff appears at v ~ 0.1 in LM representation space, which would reframe the finding as a representation learning result rather than biology-specific.
+
+This spec covers only the manylatents infrastructure changes. Experiment configs, sweep definitions, and analysis scripts belong in mbyl_for_practitioners.
+
+## Part 1: UMAP Negative Sample Rate
+
+### Problem
+
+`UMAPModule` does not expose sklearn UMAP's `negative_sample_rate` parameter. The base class `LatentModule.__init__` silently discards unrecognized `**kwargs`, so passing it via config or API has no effect. TorchDR's UMAP does not support this parameter.
+
+### Changes
+
+**`manylatents/algorithms/latent/umap.py`**
+
+Add `negative_sample_rate: int | None = None` to `UMAPModule.__init__`. Store as `self.negative_sample_rate`.
+
+In `_create_model()`, pass to sklearn UMAP only (TorchDR branch unchanged):
+
+```python
+# sklearn branch only — add negative_sample_rate
+from umap import UMAP
+return UMAP(
+    n_components=self.n_components,
+    random_state=self.random_state,
+    n_neighbors=self.n_neighbors,
+    min_dist=self.min_dist,
+    metric=self.metric,
+    n_epochs=self.n_epochs,
+    learning_rate=self.learning_rate,
+    **({"negative_sample_rate": self.negative_sample_rate}
+       if self.negative_sample_rate is not None else {}),
+)
+```
+
+When `None`, sklearn uses its default (5) — no behavior change for existing users.
+
+**`manylatents/configs/algorithms/latent/umap.yaml`**
+
+Add one line:
+
+```yaml
+negative_sample_rate: null
+```
+
+### Experiment design (downstream, not in scope)
+
+2D Hydra multirun grid in mbyl_for_practitioners:
+
+```
+negative_sample_rate in {1, 3, 5, 10}
+neighborhood_size in {3, 5, 7, 10, 15, 20, 25, 30, 50}
+```
+
+36 runs. Metrics: `trustworthiness_k`, `continuity_k`. Submitted to Mila cluster via `cluster=mila resources=gpu`.
+
+### Test
+
+New test in `tests/test_umap.py`: verify `negative_sample_rate=1` produces different embeddings than `negative_sample_rate=10` on the same data with the same seed. Confirms the parameter reaches the sklearn constructor.
+
+## Part 2: Pythia Hidden State Infrastructure
+
+### Problem
+
+The probing pipeline (HFTrainerModule + ActivationExtractor + ActivationTrajectoryCallback) is functional but has two gaps for Pythia:
+
+1. `HFTrainerModule.forward()` does not pass `output_hidden_states=True` to the HF model, so the full hidden state tuple is unavailable.
+2. No Pythia-specific configs exist — layer paths differ from GPT-2 (`gpt_neox.layers[i]` vs `transformer.h[i]`).
+
+### Changes
+
+**`manylatents/lightning/hf_trainer.py`**
+
+Add `output_hidden_states: bool = False` to `HFTrainerConfig`.
+
+Update `HFTrainerModule.forward()`:
+
+```python
+def forward(self, **inputs) -> CausalLMOutput:
+    return self.network(
+        **inputs,
+        output_hidden_states=self.config.output_hidden_states,
+    )
+```
+
+**`manylatents/configs/algorithms/lightning/hf_trainer.yaml`**
+
+Add under `config:`:
+
+```yaml
+output_hidden_states: false
+```
+
+**`manylatents/configs/callbacks/trainer/probe_pythia.yaml`** (new file)
+
+```yaml
+probe:
+  _target_: manylatents.lightning.callbacks.activation_tracker.ActivationTrajectoryCallback
+  layer_specs:
+    - _target_: manylatents.lightning.hooks.LayerSpec
+      path: "gpt_neox.layers[-1]"
+      extraction_point: "output"
+      reduce: "mean"
+  trigger:
+    _target_: manylatents.lightning.callbacks.activation_tracker.ProbeTrigger
+    every_n_steps: 500
+    on_checkpoint: true
+    on_validation_end: true
+  gauge:
+    _target_: manylatents.callbacks.diffusion_operator.DiffusionGauge
+    knn: 15
+    alpha: 1.0
+    symmetric: false
+  log_to_wandb: true
+```
+
+Users override `layer_specs` via CLI to target specific layers or add multi-layer extraction.
+
+**`manylatents/configs/experiment/representation_probe_pythia.yaml`** (new file)
+
+```yaml
+# @package _global_
+name: representation_probe_pythia
+
+defaults:
+  - override /data: wikitext
+  - override /algorithms/lightning: hf_trainer
+  - override /trainer: default
+  - override /callbacks/trainer: probe_pythia
+  - _self_
+
+seed: 42
+project: representation_probe
+debug: false
+
+data:
+  tokenizer_name: "EleutherAI/pythia-70m"
+  max_length: 128
+  batch_size: 8
+  probe_n_samples: 512
+
+algorithms:
+  lightning:
+    config:
+      model_name_or_path: "/network/weights/pythia/pythia-70m"  # local weights; tokenizer from hub
+      output_hidden_states: true
+      learning_rate: 2e-5
+      weight_decay: 0.01
+      warmup_steps: 100
+
+trainer:
+  max_epochs: 3
+  precision: bf16-mixed
+  gradient_clip_val: 1.0
+  accumulate_grad_batches: 4
+  val_check_interval: 0.5
+  log_every_n_steps: 50
+```
+
+Model size is swappable via CLI:
+
+```bash
+algorithms.lightning.config.model_name_or_path=/network/weights/pythia/pythia-410m
+data.tokenizer_name=EleutherAI/pythia-410m
+```
+
+### Pythia weights location
+
+All models available at `/network/weights/pythia/` on the Mila cluster:
+
+| Model | Path |
+|-------|------|
+| pythia-14m | `/network/weights/pythia/pythia-14m/` |
+| pythia-70m | `/network/weights/pythia/pythia-70m/` |
+| pythia-160m | `/network/weights/pythia/pythia-160m/` |
+| pythia-410m | `/network/weights/pythia/pythia-410m/` |
+| pythia-1b | `/network/weights/pythia/pythia-1b/` |
+| pythia-1.4b | `/network/weights/pythia/pythia-1.4b/` |
+| pythia-2.8b | `/network/weights/pythia/pythia-2.8b/` |
+| pythia-6.9b-deduped | `/network/weights/pythia/pythia-6.9b-deduped/` |
+| pythia-12b-deduped | `/network/weights/pythia/pythia-12b-deduped/` |
+
+Deduped variants also available for most sizes.
+
+### Test
+
+Integration test with `/network/weights/pythia/pythia-14m` (smallest checkpoint). Verifies:
+- HFTrainerModule loads with `output_hidden_states=True`
+- Forward pass output contains `.hidden_states` with expected length (n_layers + 1)
+- Probe callback fires and produces activations of expected shape
+
+Guarded with `pytest.importorskip("transformers")` and `pytest.mark.skipif(not Path("/network/weights/pythia/pythia-14m").exists(), reason="Pythia weights not available")` so GitHub CI passes.
+
+## File Change Summary
+
+| Change | File | Type |
+|---|---|---|
+| Add `negative_sample_rate` param | `algorithms/latent/umap.py` | modify |
+| Add `negative_sample_rate: null` | `configs/algorithms/latent/umap.yaml` | modify |
+| Add `output_hidden_states` field + forward passthrough | `lightning/hf_trainer.py` | modify |
+| Add `output_hidden_states: false` | `configs/algorithms/lightning/hf_trainer.yaml` | modify |
+| Pythia probe callback config | `configs/callbacks/trainer/probe_pythia.yaml` | create |
+| Pythia experiment config | `configs/experiment/representation_probe_pythia.yaml` | create |
+| UMAP negative_sample_rate test | `tests/test_umap.py` | modify |
+| Pythia integration test | `tests/test_hf_pythia.py` | create |
+
+## Out of Scope
+
+- Multi-layer extraction wrapper / `MultiLayerExtractor`
+- Sweep configs, experiment configs for mbyl_for_practitioners
+- Analysis scripts, plotting, post-hoc analysis
+- New dependencies

--- a/manylatents/algorithms/latent/umap.py
+++ b/manylatents/algorithms/latent/umap.py
@@ -21,6 +21,7 @@ class UMAPModule(LatentModule):
         n_epochs: Optional[int] = 200,
         learning_rate: float = 1.0,
         fit_fraction: float = 1.0,
+        negative_sample_rate: int | None = None,
         backend: str | None = None,
         device: str | None = None,
         neighborhood_size: Optional[int] = None,
@@ -37,6 +38,7 @@ class UMAPModule(LatentModule):
         self.n_epochs = n_epochs
         self.learning_rate = learning_rate
         self.fit_fraction = fit_fraction
+        self.negative_sample_rate = negative_sample_rate
         self.random_state = random_state
 
         self._resolved_backend = resolve_backend(backend)
@@ -56,6 +58,9 @@ class UMAPModule(LatentModule):
         else:
             from umap import UMAP
 
+            kwargs = {}
+            if self.negative_sample_rate is not None:
+                kwargs["negative_sample_rate"] = self.negative_sample_rate
             return UMAP(
                 n_components=self.n_components,
                 random_state=self.random_state,
@@ -64,6 +69,7 @@ class UMAPModule(LatentModule):
                 metric=self.metric,
                 n_epochs=self.n_epochs,
                 learning_rate=self.learning_rate,
+                **kwargs,
             )
 
     def fit(self, x, y=None) -> None:

--- a/manylatents/configs/algorithms/latent/umap.yaml
+++ b/manylatents/configs/algorithms/latent/umap.yaml
@@ -7,6 +7,7 @@ n_epochs: 500
 metric: 'euclidean'
 learning_rate: 1.0
 fit_fraction: 1.0
+negative_sample_rate: null
 neighborhood_size: ${neighborhood_size}
 backend: null
 device: null

--- a/manylatents/configs/algorithms/lightning/hf_trainer.yaml
+++ b/manylatents/configs/algorithms/lightning/hf_trainer.yaml
@@ -10,4 +10,5 @@ config:
   warmup_steps: 100
   adam_epsilon: 1e-8
   trust_remote_code: false
+  output_hidden_states: false
   # Optional: torch_dtype, attn_implementation

--- a/manylatents/configs/callbacks/trainer/probe_pythia.yaml
+++ b/manylatents/configs/callbacks/trainer/probe_pythia.yaml
@@ -1,0 +1,21 @@
+# Pythia representation probe callback configuration
+# Layer path uses gpt_neox.layers[] (GPT-NeoX architecture)
+# Override layer_specs via CLI for multi-layer or specific-layer extraction
+probe:
+  _target_: manylatents.lightning.callbacks.activation_tracker.ActivationTrajectoryCallback
+  layer_specs:
+    - _target_: manylatents.lightning.hooks.LayerSpec
+      path: "gpt_neox.layers[-1]"
+      extraction_point: "output"
+      reduce: "mean"
+  trigger:
+    _target_: manylatents.lightning.callbacks.activation_tracker.ProbeTrigger
+    every_n_steps: 500
+    on_checkpoint: true
+    on_validation_end: true
+  gauge:
+    _target_: manylatents.callbacks.diffusion_operator.DiffusionGauge
+    knn: 15
+    alpha: 1.0
+    symmetric: false
+  log_to_wandb: true

--- a/manylatents/configs/data/pile.yaml
+++ b/manylatents/configs/data/pile.yaml
@@ -1,0 +1,17 @@
+# The Pile — Pythia's training data, loaded from Mila cluster local shards
+# Uses jsonl.zst format; num_shards/max_train_samples control scale
+_target_: manylatents.data.text.HFTextDataModule
+dataset_name: null
+dataset_config: null
+data_dir: "/network/datasets/pile"
+train_files: "train/*.jsonl.zst"
+val_files: "val.jsonl.zst"
+text_column: "text"
+tokenizer_name: "EleutherAI/pythia-70m"
+max_length: 128
+batch_size: 8
+num_workers: 0
+probe_n_samples: 512
+num_shards: 1
+max_train_samples: 50000
+seed: ${seed}

--- a/manylatents/configs/data/wikitext.yaml
+++ b/manylatents/configs/data/wikitext.yaml
@@ -2,7 +2,7 @@
 # Text data for HuggingFace language model training
 # Note: Does not inherit from default.yaml (different DataModule interface)
 
-_target_: manylatents.data.text.TextDataModule
+_target_: manylatents.data.text.HFTextDataModule
 
 dataset_name: "wikitext"
 dataset_config: "wikitext-2-raw-v1"

--- a/manylatents/configs/experiment/representation_probe_pythia.yaml
+++ b/manylatents/configs/experiment/representation_probe_pythia.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 #
 # End-to-end experiment for representation probing on Pythia models.
+# Uses The Pile (Pythia's training data) from Mila cluster local shards.
 #
 # Usage:
 #   python -m manylatents.main experiment=representation_probe_pythia
@@ -11,7 +12,7 @@
 name: representation_probe_pythia
 
 defaults:
-  - override /data: wikitext
+  - override /data: pile
   - override /algorithms/lightning: hf_trainer
   - override /trainer: default
   - override /callbacks/trainer: probe_pythia
@@ -23,9 +24,6 @@ debug: false
 
 # --- Data Configuration ---
 data:
-  tokenizer_name: "EleutherAI/pythia-70m"
-  max_length: 128
-  batch_size: 8
   probe_n_samples: 512
 
 # --- Model Configuration ---
@@ -33,7 +31,7 @@ data:
 algorithms:
   lightning:
     config:
-      model_name_or_path: "/network/weights/pythia/pythia-70m"
+      model_name_or_path: "/network/weights/pythia/pythia-70m/step143000"
       output_hidden_states: true
       learning_rate: 2e-5
       weight_decay: 0.01

--- a/manylatents/configs/experiment/representation_probe_pythia.yaml
+++ b/manylatents/configs/experiment/representation_probe_pythia.yaml
@@ -1,0 +1,49 @@
+# @package _global_
+#
+# End-to-end experiment for representation probing on Pythia models.
+#
+# Usage:
+#   python -m manylatents.main experiment=representation_probe_pythia
+#   python -m manylatents.main experiment=representation_probe_pythia \
+#       algorithms.lightning.config.model_name_or_path=/network/weights/pythia/pythia-410m \
+#       data.tokenizer_name=EleutherAI/pythia-410m
+#
+name: representation_probe_pythia
+
+defaults:
+  - override /data: wikitext
+  - override /algorithms/lightning: hf_trainer
+  - override /trainer: default
+  - override /callbacks/trainer: probe_pythia
+  - _self_
+
+seed: 42
+project: representation_probe
+debug: false
+
+# --- Data Configuration ---
+data:
+  tokenizer_name: "EleutherAI/pythia-70m"
+  max_length: 128
+  batch_size: 8
+  probe_n_samples: 512
+
+# --- Model Configuration ---
+# Weights are local on Mila cluster; tokenizer loaded from HuggingFace hub
+algorithms:
+  lightning:
+    config:
+      model_name_or_path: "/network/weights/pythia/pythia-70m"
+      output_hidden_states: true
+      learning_rate: 2e-5
+      weight_decay: 0.01
+      warmup_steps: 100
+
+# --- Trainer Configuration ---
+trainer:
+  max_epochs: 3
+  precision: bf16-mixed
+  gradient_clip_val: 1.0
+  accumulate_grad_batches: 4
+  val_check_interval: 0.5
+  log_every_n_steps: 50

--- a/manylatents/data/text.py
+++ b/manylatents/data/text.py
@@ -38,8 +38,19 @@ class HFTextDataModule(LightningDataModule):
 
     def __init__(
         self,
-        dataset_name: str = "wikitext",
-        dataset_config: str = "wikitext-2-raw-v1",
+        # Source: hub (existing)
+        dataset_name: str | None = "wikitext",
+        dataset_config: str | None = "wikitext-2-raw-v1",
+        # Source: local
+        data_dir: str | None = None,
+        train_files: str = "train/*.jsonl.zst",
+        val_files: str = "val.jsonl.zst",
+        text_column: str = "text",
+        # Scale control
+        max_train_samples: int | None = None,
+        max_val_samples: int | None = None,
+        num_shards: int | None = None,
+        # Existing (unchanged)
         tokenizer_name: str = "gpt2",
         max_length: int = 128,
         batch_size: int = 8,
@@ -50,6 +61,13 @@ class HFTextDataModule(LightningDataModule):
         super().__init__()
         self.dataset_name = dataset_name
         self.dataset_config = dataset_config
+        self.data_dir = data_dir
+        self.train_files = train_files
+        self.val_files = val_files
+        self.text_column = text_column
+        self.max_train_samples = max_train_samples
+        self.max_val_samples = max_val_samples
+        self.num_shards = num_shards
         self.tokenizer_name = tokenizer_name
         self.max_length = max_length
         self.batch_size = batch_size
@@ -62,25 +80,69 @@ class HFTextDataModule(LightningDataModule):
         self.val_dataset = None
         self.probe_dataset = None
 
-    def prepare_data(self):
-        """Download dataset and tokenizer."""
+    def _load_hub(self):
+        """Load dataset from HuggingFace Hub."""
         from datasets import load_dataset
-        load_dataset(self.dataset_name, self.dataset_config)
+        return load_dataset(self.dataset_name, self.dataset_config)
+
+    def _load_local(self):
+        """Load dataset from local jsonl/jsonl.zst shards."""
+        from datasets import load_dataset
+        from glob import glob
+        from pathlib import Path
+
+        base = Path(self.data_dir)
+        train_paths = sorted(glob(str(base / self.train_files)))
+        val_paths = sorted(glob(str(base / self.val_files)))
+
+        if self.num_shards is not None:
+            train_paths = train_paths[:self.num_shards]
+
+        if not train_paths:
+            raise FileNotFoundError(f"No train files matching {base / self.train_files}")
+        if not val_paths:
+            raise FileNotFoundError(f"No val files matching {base / self.val_files}")
+
+        # Resolve symlinks (git-annex on Mila stores data behind symlinks)
+        train_paths = [str(Path(p).resolve()) for p in train_paths]
+        val_paths = [str(Path(p).resolve()) for p in val_paths]
+
+        return load_dataset("json", data_files={
+            "train": train_paths,
+            "validation": val_paths,
+        })
+
+    def prepare_data(self):
+        """Download dataset and tokenizer (hub mode only)."""
+        if self.data_dir is None:
+            from datasets import load_dataset
+            load_dataset(self.dataset_name, self.dataset_config)
         AutoTokenizer.from_pretrained(self.tokenizer_name)
 
     def setup(self, stage: Optional[str] = None):
         """Tokenize and prepare datasets."""
-        from datasets import load_dataset
-
         self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
-        dataset = load_dataset(self.dataset_name, self.dataset_config)
+        if self.data_dir is not None:
+            dataset = self._load_local()
+        else:
+            dataset = self._load_hub()
+
+        # Apply sample caps
+        if self.max_train_samples is not None:
+            n = min(self.max_train_samples, len(dataset["train"]))
+            dataset["train"] = dataset["train"].select(range(n))
+        if self.max_val_samples is not None:
+            n = min(self.max_val_samples, len(dataset["validation"]))
+            dataset["validation"] = dataset["validation"].select(range(n))
+
+        text_column = self.text_column
 
         def tokenize_fn(examples):
             # Filter empty strings
-            texts = [t for t in examples["text"] if t.strip()]
+            texts = [t for t in examples[text_column] if t.strip()]
             if not texts:
                 return {"input_ids": [], "attention_mask": [], "labels": []}
 
@@ -96,10 +158,10 @@ class HFTextDataModule(LightningDataModule):
 
         # Tokenize datasets
         self.train_dataset = TokenizedDataset(
-            dataset["train"], tokenize_fn, self.max_length
+            dataset["train"], tokenize_fn, self.max_length, self.text_column
         )
         self.val_dataset = TokenizedDataset(
-            dataset["validation"], tokenize_fn, self.max_length
+            dataset["validation"], tokenize_fn, self.max_length, self.text_column
         )
 
         # Create fixed probe subset
@@ -154,16 +216,17 @@ class HFTextDataModule(LightningDataModule):
 class TokenizedDataset(Dataset):
     """Lazily tokenized dataset wrapper."""
 
-    def __init__(self, hf_dataset, tokenize_fn, max_length: int):
+    def __init__(self, hf_dataset, tokenize_fn, max_length: int, text_column: str = "text"):
         self.hf_dataset = hf_dataset
         self.tokenize_fn = tokenize_fn
         self.max_length = max_length
+        self.text_column = text_column
         self._cache = {}
 
         # Pre-filter to non-empty texts
         self.valid_indices = [
             i for i, ex in enumerate(hf_dataset)
-            if ex["text"].strip()
+            if ex[self.text_column].strip()
         ]
 
     def __len__(self):
@@ -173,7 +236,7 @@ class TokenizedDataset(Dataset):
         real_idx = self.valid_indices[idx]
         if real_idx not in self._cache:
             example = self.hf_dataset[real_idx]
-            tokenized = self.tokenize_fn({"text": [example["text"]]})
+            tokenized = self.tokenize_fn({self.text_column: [example[self.text_column]]})
             self._cache[real_idx] = {
                 "input_ids": tokenized["input_ids"][0],
                 "attention_mask": tokenized["attention_mask"][0],

--- a/manylatents/data/text.py
+++ b/manylatents/data/text.py
@@ -10,7 +10,7 @@ from transformers import AutoTokenizer
 
 
 @dataclass
-class TextDataConfig:
+class HFTextDataConfig:
     """Configuration for text data module.
 
     Attributes:
@@ -29,7 +29,7 @@ class TextDataConfig:
     num_workers: int = 0
 
 
-class TextDataModule(LightningDataModule):
+class HFTextDataModule(LightningDataModule):
     """Lightning DataModule for text data with HuggingFace models.
 
     Loads a HuggingFace dataset, tokenizes it, and provides DataLoaders
@@ -180,3 +180,8 @@ class TokenizedDataset(Dataset):
                 "labels": tokenized["labels"][0],
             }
         return self._cache[real_idx]
+
+
+# Backward compatibility aliases
+TextDataModule = HFTextDataModule
+TextDataConfig = HFTextDataConfig

--- a/manylatents/data/text.py
+++ b/manylatents/data/text.py
@@ -1,32 +1,11 @@
 # manylatents/data/text.py
 """Text data module for HuggingFace language models."""
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
 from lightning import LightningDataModule
 from torch.utils.data import DataLoader, Dataset, Subset
 from transformers import AutoTokenizer
-
-
-@dataclass
-class HFTextDataConfig:
-    """Configuration for text data module.
-
-    Attributes:
-        dataset_name: HuggingFace dataset name (e.g., "wikitext")
-        dataset_config: Dataset config (e.g., "wikitext-2-raw-v1")
-        tokenizer_name: Tokenizer to use (defaults to model name)
-        max_length: Maximum sequence length
-        batch_size: Training batch size
-        num_workers: DataLoader workers
-    """
-    dataset_name: str = "wikitext"
-    dataset_config: str = "wikitext-2-raw-v1"
-    tokenizer_name: Optional[str] = None
-    max_length: int = 128
-    batch_size: int = 8
-    num_workers: int = 0
 
 
 class HFTextDataModule(LightningDataModule):
@@ -245,6 +224,5 @@ class TokenizedDataset(Dataset):
         return self._cache[real_idx]
 
 
-# Backward compatibility aliases
+# Backward compatibility alias
 TextDataModule = HFTextDataModule
-TextDataConfig = HFTextDataConfig

--- a/manylatents/lightning/callbacks/activation_tracker.py
+++ b/manylatents/lightning/callbacks/activation_tracker.py
@@ -139,7 +139,7 @@ class ActivationTrajectoryCallback(Callback):
                 raise ValueError(
                     "probe_loader not provided and datamodule has no probe_dataloader() method. "
                     "Either pass probe_loader to ActivationTrajectoryCallback or use a datamodule "
-                    "with probe_dataloader() (e.g., TextDataModule)."
+                    "with probe_dataloader() (e.g., HFTextDataModule)."
                 )
 
     def _sanitize_layer_name(self, layer: str) -> str:

--- a/manylatents/lightning/hf_trainer.py
+++ b/manylatents/lightning/hf_trainer.py
@@ -26,6 +26,7 @@ class HFTrainerConfig:
         torch_dtype: Optional dtype for model (e.g., torch.bfloat16)
         trust_remote_code: Whether to trust remote code for model loading
         attn_implementation: Attention implementation (e.g., "flash_attention_2")
+        output_hidden_states: Whether to return hidden states from all layers
         device_map: Device placement strategy (e.g., "auto"). None lets
             Lightning/FSDP manage placement (existing behavior).
     """
@@ -37,6 +38,7 @@ class HFTrainerConfig:
     torch_dtype: Optional[torch.dtype] = None
     trust_remote_code: bool = False
     attn_implementation: Optional[str] = None
+    output_hidden_states: bool = False
     device_map: Optional[str] = None
 
 
@@ -82,7 +84,10 @@ class HFTrainerModule(LightningModule):
 
     def forward(self, **inputs) -> CausalLMOutput:
         """Forward pass through the model."""
-        return self.network(**inputs)
+        return self.network(
+            **inputs,
+            output_hidden_states=self.config.output_hidden_states,
+        )
 
     def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int):
         """Standard training step."""

--- a/manylatents/lightning/tests/test_hf_trainer.py
+++ b/manylatents/lightning/tests/test_hf_trainer.py
@@ -120,3 +120,70 @@ def test_hf_trainer_with_activation_extractor():
     # Should have (batch_size, hidden_dim) after mean reduction
     assert activations["transformer.h[-1]"].shape[0] == 3  # 3 samples
     assert len(activations["transformer.h[-1]"].shape) == 2  # (batch, hidden)
+
+
+def test_hf_trainer_config_output_hidden_states_default():
+    """output_hidden_states should default to False."""
+    config = HFTrainerConfig(model_name_or_path="gpt2")
+    assert config.output_hidden_states is False
+
+
+@pytest.mark.slow
+def test_hf_trainer_output_hidden_states():
+    """forward() with output_hidden_states=True returns hidden state tuple."""
+    config = HFTrainerConfig(
+        model_name_or_path="sshleifer/tiny-gpt2",
+        output_hidden_states=True,
+    )
+    module = HFTrainerModule(config)
+    module.configure_model()
+
+    tokenizer = module.tokenizer
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    batch = tokenizer(
+        ["Hello world", "Test input"],
+        return_tensors="pt",
+        padding=True,
+        max_length=32,
+    )
+
+    module.eval()
+    with torch.no_grad():
+        outputs = module(**batch)
+
+    assert outputs.hidden_states is not None
+    # hidden_states is a tuple of (n_layers + 1) tensors (embedding + each layer)
+    n_layers = module.network.config.num_hidden_layers
+    assert len(outputs.hidden_states) == n_layers + 1
+    # Each tensor: (batch, seq_len, hidden_dim)
+    assert outputs.hidden_states[0].shape[0] == 2  # batch_size
+
+
+@pytest.mark.slow
+def test_hf_trainer_output_hidden_states_disabled():
+    """forward() with output_hidden_states=False returns None for hidden_states."""
+    config = HFTrainerConfig(
+        model_name_or_path="sshleifer/tiny-gpt2",
+        output_hidden_states=False,
+    )
+    module = HFTrainerModule(config)
+    module.configure_model()
+
+    tokenizer = module.tokenizer
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    batch = tokenizer(
+        ["Hello world"],
+        return_tensors="pt",
+        padding=True,
+        max_length=32,
+    )
+
+    module.eval()
+    with torch.no_grad():
+        outputs = module(**batch)
+
+    assert outputs.hidden_states is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # HuggingFace trainer support
-hf = ["transformers>=4.40"]
+hf = ["transformers>=4.40", "datasets>=3.0"]
 # GPU-accelerated DR via TorchDR
 torchdr = [
     "torchdr>=0.3,<0.4",

--- a/tests/test_hf_text_datamodule.py
+++ b/tests/test_hf_text_datamodule.py
@@ -1,0 +1,197 @@
+"""Tests for HFTextDataModule local loading and scale controls."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from manylatents.data.text import HFTextDataModule
+
+
+class TestLocalLoading:
+    """Test _load_local() with mock jsonl files."""
+
+    @pytest.fixture
+    def mock_pile_dir(self, tmp_path):
+        """Create a mock Pile-like directory with jsonl files."""
+        train_dir = tmp_path / "train"
+        train_dir.mkdir()
+
+        # Create 3 small shard files
+        for i in range(3):
+            shard = train_dir / f"{i:02d}.jsonl"
+            lines = [
+                json.dumps({"text": f"Shard {i} example {j}.", "meta": {"pile_set_name": "test"}})
+                for j in range(20)
+            ]
+            shard.write_text("\n".join(lines))
+
+        # Create val file
+        val_file = tmp_path / "val.jsonl"
+        lines = [
+            json.dumps({"text": f"Val example {j}.", "meta": {"pile_set_name": "test"}})
+            for j in range(50)
+        ]
+        val_file.write_text("\n".join(lines))
+
+        return tmp_path
+
+    def test_load_local_basic(self, mock_pile_dir):
+        """Local mode loads train and val from jsonl files."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            seed=42,
+        )
+        dm.setup()
+        assert dm.train_dataset is not None
+        assert dm.val_dataset is not None
+        assert len(dm.train_dataset) > 0
+        assert len(dm.val_dataset) > 0
+
+    def test_num_shards(self, mock_pile_dir):
+        """num_shards=2 loads only 2 of 3 available shards."""
+        dm_all = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+        )
+        dm_all.setup()
+        n_all = len(dm_all.train_dataset)
+
+        dm_2 = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            num_shards=2,
+        )
+        dm_2.setup()
+        n_2 = len(dm_2.train_dataset)
+
+        assert n_2 < n_all
+
+    def test_max_train_samples(self, mock_pile_dir):
+        """max_train_samples caps the training set."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            max_train_samples=10,
+        )
+        dm.setup()
+        # 10 max, but some may be empty after filtering
+        assert len(dm.train_dataset) <= 10
+
+    def test_max_val_samples(self, mock_pile_dir):
+        """max_val_samples caps the validation set."""
+        dm = HFTextDataModule(
+            data_dir=str(mock_pile_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+            max_val_samples=5,
+        )
+        dm.setup()
+        assert len(dm.val_dataset) <= 5
+
+    def test_text_column(self, mock_pile_dir):
+        """Custom text_column reads from the correct field."""
+        custom_dir = mock_pile_dir / "custom"
+        custom_dir.mkdir()
+        train_dir = custom_dir / "train"
+        train_dir.mkdir()
+        shard = train_dir / "00.jsonl"
+        lines = [
+            json.dumps({"content": f"Custom col example {j}."})
+            for j in range(20)
+        ]
+        shard.write_text("\n".join(lines))
+        val = custom_dir / "val.jsonl"
+        lines = [
+            json.dumps({"content": f"Custom col val {j}."})
+            for j in range(10)
+        ]
+        val.write_text("\n".join(lines))
+
+        dm = HFTextDataModule(
+            data_dir=str(custom_dir),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            text_column="content",
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=5,
+        )
+        dm.setup()
+        assert len(dm.train_dataset) > 0
+        item = dm.train_dataset[0]
+        assert "input_ids" in item
+
+    def test_missing_train_files_raises(self, tmp_path):
+        """FileNotFoundError when no train files match the glob."""
+        (tmp_path / "val.jsonl").write_text(json.dumps({"text": "hi"}))
+        dm = HFTextDataModule(
+            data_dir=str(tmp_path),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+        )
+        with pytest.raises(FileNotFoundError, match="No train files"):
+            dm.setup()
+
+    def test_missing_val_files_raises(self, tmp_path):
+        """FileNotFoundError when no val files match the glob."""
+        train_dir = tmp_path / "train"
+        train_dir.mkdir()
+        (train_dir / "00.jsonl").write_text(json.dumps({"text": "hi"}))
+        dm = HFTextDataModule(
+            data_dir=str(tmp_path),
+            train_files="train/*.jsonl",
+            val_files="val.jsonl",
+            tokenizer_name="gpt2",
+        )
+        with pytest.raises(FileNotFoundError, match="No val files"):
+            dm.setup()
+
+
+class TestHubLoadingUnchanged:
+    """Verify hub loading still works after refactor."""
+
+    def test_default_hub_mode(self):
+        """data_dir=None means hub mode (existing behavior)."""
+        dm = HFTextDataModule(
+            tokenizer_name="gpt2",
+            max_length=32,
+            batch_size=4,
+            probe_n_samples=8,
+        )
+        assert dm.data_dir is None
+        assert dm.dataset_name == "wikitext"
+
+    def test_backward_compat_alias(self):
+        """TextDataModule alias still works."""
+        from manylatents.data.text import TextDataModule
+        dm = TextDataModule(tokenizer_name="gpt2")
+        assert isinstance(dm, HFTextDataModule)

--- a/tests/test_hf_text_datamodule.py
+++ b/tests/test_hf_text_datamodule.py
@@ -1,6 +1,5 @@
 """Tests for HFTextDataModule local loading and scale controls."""
 import json
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_umap_backend.py
+++ b/tests/test_umap_backend.py
@@ -115,3 +115,39 @@ def test_umap_backend_output_agreement():
     # Kernel non-negative
     assert K_cpu.min() >= -1e-7, f"CPU kernel has negative values: {K_cpu.min()}"
     assert K_tdr.min() >= -1e-7, f"TorchDR kernel has negative values: {K_tdr.min()}"
+
+
+def test_umap_negative_sample_rate_affects_embedding():
+    """negative_sample_rate should reach sklearn UMAP and change the embedding."""
+    from manylatents.algorithms.latent.umap import UMAPModule
+
+    x = torch.randn(80, 10, generator=torch.Generator().manual_seed(0))
+
+    m1 = UMAPModule(
+        n_components=2, random_state=42, n_neighbors=10,
+        n_epochs=50, negative_sample_rate=1,
+    )
+    emb1 = m1.fit_transform(x)
+
+    m2 = UMAPModule(
+        n_components=2, random_state=42, n_neighbors=10,
+        n_epochs=50, negative_sample_rate=10,
+    )
+    emb2 = m2.fit_transform(x)
+
+    # Same seed, same data, different negative_sample_rate -> different embeddings
+    assert emb1.shape == emb2.shape == (80, 2)
+    assert not np.allclose(emb1, emb2, atol=1e-3), (
+        "Embeddings should differ when negative_sample_rate changes"
+    )
+
+
+def test_umap_negative_sample_rate_none_uses_default():
+    """negative_sample_rate=None should not change default sklearn behavior."""
+    from manylatents.algorithms.latent.umap import UMAPModule
+
+    m = UMAPModule(n_components=2, random_state=42, n_neighbors=5, n_epochs=10)
+    assert m.negative_sample_rate is None
+    # sklearn default is 5 — verify it's not overridden
+    from umap import UMAP as SklearnUMAP
+    assert m.model.negative_sample_rate == SklearnUMAP().negative_sample_rate


### PR DESCRIPTION
## Summary

- **Rename** `TextDataModule` → `HFTextDataModule` (backward-compat alias preserved)
- **Add local shard loading** via `data_dir` param — loads `.jsonl.zst` files with `load_dataset("json", data_files=...)` for The Pile on Mila cluster
- **Scale controls**: `num_shards` (load subset of train shards), `max_train_samples`, `max_val_samples`
- **`text_column`** param — configurable column name instead of hardcoded `"text"`
- **New config**: `data/pile.yaml` pointing at `/network/datasets/pile` (1 shard, 50K samples default)
- **Updated** `representation_probe_pythia.yaml` to use Pile data + correct Pythia weight path (`step143000`)

## Motivation

The Pythia representation probe was configured with WikiText, but Pythia was trained on The Pile. Probing on OOD data confounds interpretability results. The Pile is available locally on the Mila cluster as git-annex symlinked `.jsonl.zst` shards.

## Test plan

- [x] 9 new tests in `tests/test_hf_text_datamodule.py` (local loading, num_shards, max_samples, text_column, error paths, hub mode, backward compat)
- [x] 546 passed, 14 skipped in full `tests/` suite
- [x] 17 passed in `callbacks/tests/`
- [x] 98 passed in config composition (including new `pile` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)