### PR TITLE
feat: ImportanceSampling + KStarWeightedSampling

### DIFF
--- a/manylatents/utils/sampling.py
+++ b/manylatents/utils/sampling.py
@@ -657,6 +657,138 @@ class ImportanceSampling:
         return subsampled_embeddings, subsampled_ds, indices
 
 
+class KStarWeightedSampling:
+    """
+    Geometry-aware sampling that preserves manifold boundary points.
+
+    Computes per-point k* (the neighborhood scale at which local geometry
+    breaks down) and upweights points with low k*, which tend to lie at
+    manifold boundaries, high-curvature regions, or density transitions.
+
+    Note on circularity: k* is computed from the same kNN graph structure
+    used by the mismatch ratio diagnostic. When this sampler is used
+    upstream of mismatch ratio evaluation, the sampling and evaluation
+    share geometric assumptions. This is intentional — the sampler
+    preserves the boundary points that the mismatch ratio is designed
+    to detect — but users should be aware of the shared structure.
+
+    Weights: ``w_i = k_max - k_star_i + 1`` (low k* -> high weight).
+    """
+
+    def __init__(
+        self,
+        k_max: int = 200,
+        seed: int = 42,
+        fraction: Optional[float] = None,
+        n_samples: Optional[int] = None,
+    ):
+        """
+        Initialize KStarWeightedSampling.
+
+        Args:
+            k_max: Maximum neighborhood size for k* computation.
+            seed: Default random seed (can be overridden at call time).
+            fraction: Default fraction of samples.
+            n_samples: Default number of samples.
+        """
+        self.k_max = k_max
+        self.seed = seed
+        self.fraction = fraction
+        self.n_samples = n_samples
+
+    def get_indices(
+        self,
+        data_or_n_total: Union[np.ndarray, int],
+        n_samples: Optional[int] = None,
+        fraction: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> np.ndarray:
+        """
+        Compute geometry-aware sample indices from a data array.
+
+        Points with low k* (boundary/high-curvature regions) receive
+        higher sampling probability.
+
+        Args:
+            data_or_n_total: Data array to compute k* on.
+                Must be an ndarray (integer input is rejected).
+            n_samples: Absolute number of samples to take.
+            fraction: Fraction of samples to take.
+            seed: Random seed (overrides instance seed).
+
+        Returns:
+            Sorted array of selected indices.
+
+        Raises:
+            TypeError: If data_or_n_total is an integer (k* requires data).
+        """
+        if isinstance(data_or_n_total, int):
+            raise TypeError(
+                "KStarWeightedSampling requires a data array for k* computation, "
+                "got an integer. Pass the data matrix instead."
+            )
+
+        from manylatents.metrics.mismatch_ratio import _compute_kstar
+
+        n_samples = n_samples if n_samples is not None else self.n_samples
+        fraction = fraction if fraction is not None else self.fraction
+        seed = seed if seed is not None else self.seed
+
+        data = data_or_n_total
+        n = len(data)
+        n_keep = _compute_n_samples(n, n_samples, fraction)
+        rng = np.random.default_rng(seed)
+
+        # Compute per-point k*
+        k_star, _ = _compute_kstar(data, k_max=self.k_max)
+
+        # Weights: low k* -> high weight
+        weights = (self.k_max - k_star + 1).astype(np.float64)
+
+        # Safety: clamp non-positive weights
+        weights[weights <= 0] = 1.0
+
+        # Log boundary point statistics
+        median_kstar = np.median(k_star)
+        n_boundary = int(np.sum(k_star < median_kstar))
+        logger.info(
+            f"KStarWeightedSampling: {n_boundary}/{n} boundary points "
+            f"(k* < median={median_kstar:.0f})"
+        )
+
+        # Probabilistic draw without replacement
+        prob = weights / weights.sum()
+        indices = rng.choice(n, size=n_keep, replace=False, p=prob)
+
+        logger.info(
+            f"KStarWeightedSampling: {n} -> {n_keep} samples "
+            f"(k_max={self.k_max}, seed={seed})"
+        )
+
+        return np.sort(indices)
+
+    def sample(
+        self,
+        embeddings: np.ndarray,
+        dataset: object,
+        n_samples: Optional[int] = None,
+        fraction: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> Tuple[np.ndarray, object, np.ndarray]:
+        """Sample using k*-weighted geometry-aware selection."""
+        # Use instance defaults if not overridden
+        n_samples = n_samples if n_samples is not None else self.n_samples
+        fraction = fraction if fraction is not None else self.fraction
+        seed = seed if seed is not None else self.seed
+
+        indices = self.get_indices(embeddings, n_samples, fraction, seed)
+
+        subsampled_embeddings = embeddings[indices]
+        subsampled_ds = _subsample_dataset_metadata(dataset, indices)
+
+        return subsampled_embeddings, subsampled_ds, indices
+
+
 class FixedIndexSampling:
     """
     Use precomputed indices for reproducible cross-setting comparisons.

--- a/manylatents/utils/sampling.py
+++ b/manylatents/utils/sampling.py
@@ -526,6 +526,137 @@ class FarthestPointSampling:
         return subsampled_embeddings, subsampled_ds, indices
 
 
+class ImportanceSampling:
+    """
+    Density-inverse sampling via kNN radius weighting.
+
+    Assigns each point a weight proportional to the distance to its k-th
+    nearest neighbor raised to a power alpha. Points in sparse regions
+    (large kNN radius) receive higher sampling probability, counteracting
+    density bias.
+
+    Weights are capped at the 99th percentile to prevent outlier
+    oversampling, and zero weights are replaced with the minimum nonzero
+    weight.
+    """
+
+    def __init__(
+        self,
+        k: int = 15,
+        alpha: float = 1.0,
+        seed: int = 42,
+        fraction: Optional[float] = None,
+        n_samples: Optional[int] = None,
+    ):
+        """
+        Initialize ImportanceSampling.
+
+        Args:
+            k: Number of neighbors for kNN radius computation.
+            alpha: Exponent for the distance weight (higher = stronger
+                density correction).
+            seed: Default random seed (can be overridden at call time).
+            fraction: Default fraction of samples.
+            n_samples: Default number of samples.
+        """
+        self.k = k
+        self.alpha = alpha
+        self.seed = seed
+        self.fraction = fraction
+        self.n_samples = n_samples
+
+    def get_indices(
+        self,
+        data_or_n_total: Union[np.ndarray, int],
+        n_samples: Optional[int] = None,
+        fraction: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> np.ndarray:
+        """
+        Compute density-inverse sample indices from a data array.
+
+        Args:
+            data_or_n_total: Data array to compute kNN distances on.
+                Must be an ndarray (integer input is rejected).
+            n_samples: Absolute number of samples to take.
+            fraction: Fraction of samples to take.
+            seed: Random seed (overrides instance seed).
+
+        Returns:
+            Sorted array of selected indices.
+
+        Raises:
+            TypeError: If data_or_n_total is an integer (kNN requires data).
+        """
+        if isinstance(data_or_n_total, int):
+            raise TypeError(
+                "ImportanceSampling requires a data array for kNN computation, "
+                "got an integer. Pass the data matrix instead."
+            )
+
+        from sklearn.neighbors import NearestNeighbors
+
+        n_samples = n_samples if n_samples is not None else self.n_samples
+        fraction = fraction if fraction is not None else self.fraction
+        seed = seed if seed is not None else self.seed
+
+        data = data_or_n_total
+        n = len(data)
+        n_keep = _compute_n_samples(n, n_samples, fraction)
+        rng = np.random.default_rng(seed)
+
+        # Compute distance to k-th nearest neighbor for each point
+        nn = NearestNeighbors(n_neighbors=self.k + 1, algorithm="auto")
+        nn.fit(data)
+        distances, _ = nn.kneighbors(data)
+        # distances[:, 0] is self-distance (0); k-th neighbor is at index k
+        radii = distances[:, self.k]
+
+        # Compute weights: w_i = r_i^alpha
+        weights = radii ** self.alpha
+
+        # Cap at 99th percentile to prevent outlier oversampling
+        cap = np.percentile(weights, 99)
+        weights = np.minimum(weights, cap)
+
+        # Replace zero weights with minimum nonzero weight
+        nonzero_mask = weights > 0
+        if nonzero_mask.any():
+            weights[~nonzero_mask] = weights[nonzero_mask].min()
+
+        # Probabilistic draw without replacement
+        prob = weights / weights.sum()
+        indices = rng.choice(n, size=n_keep, replace=False, p=prob)
+
+        logger.info(
+            f"ImportanceSampling: {n} -> {n_keep} samples "
+            f"(k={self.k}, alpha={self.alpha}, seed={seed})"
+        )
+
+        return np.sort(indices)
+
+    def sample(
+        self,
+        embeddings: np.ndarray,
+        dataset: object,
+        n_samples: Optional[int] = None,
+        fraction: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> Tuple[np.ndarray, object, np.ndarray]:
+        """Sample using density-inverse kNN weighting."""
+        # Use instance defaults if not overridden
+        n_samples = n_samples if n_samples is not None else self.n_samples
+        fraction = fraction if fraction is not None else self.fraction
+        seed = seed if seed is not None else self.seed
+
+        indices = self.get_indices(embeddings, n_samples, fraction, seed)
+
+        subsampled_embeddings = embeddings[indices]
+        subsampled_ds = _subsample_dataset_metadata(dataset, indices)
+
+        return subsampled_embeddings, subsampled_ds, indices
+
+
 class FixedIndexSampling:
     """
     Use precomputed indices for reproducible cross-setting comparisons.

--- a/tests/test_sampling_importance_kstar.py
+++ b/tests/test_sampling_importance_kstar.py
@@ -1,0 +1,162 @@
+"""Tests for ImportanceSampling and KStarWeightedSampling."""
+
+import numpy as np
+import pytest
+
+from manylatents.utils.sampling import ImportanceSampling, KStarWeightedSampling
+
+
+class MockDataset:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_data(n=500, d=10, seed=0):
+    """Return (n, d) float32 data from a reproducible RNG."""
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n, d)).astype(np.float32)
+
+
+def _make_dense_sparse(n_dense=400, n_sparse=100, d=10, seed=0):
+    """400 dense points (std=0.1) + 100 sparse points (std=2.0)."""
+    rng = np.random.default_rng(seed)
+    dense = (rng.standard_normal((n_dense, d)) * 0.1).astype(np.float32)
+    sparse = (rng.standard_normal((n_sparse, d)) * 2.0).astype(np.float32)
+    return np.vstack([dense, sparse])
+
+
+def _make_two_clusters(n_per_cluster=300, d=10, seed=0):
+    """Two clusters separated by 5 in dimension 0."""
+    rng = np.random.default_rng(seed)
+    c0 = rng.standard_normal((n_per_cluster, d)).astype(np.float32)
+    c1 = rng.standard_normal((n_per_cluster, d)).astype(np.float32)
+    c1[:, 0] += 5.0
+    return np.vstack([c0, c1])
+
+
+# ---------------------------------------------------------------------------
+# TestImportanceSampling
+# ---------------------------------------------------------------------------
+
+class TestImportanceSampling:
+    def test_output_size(self):
+        data = _make_data(500, 10)
+        sampler = ImportanceSampling(k=10, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert len(idx) == 250
+
+    def test_sorted_indices(self):
+        data = _make_data(500, 10)
+        sampler = ImportanceSampling(k=10, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert np.all(np.diff(idx) >= 0)
+
+    def test_no_duplicates(self):
+        data = _make_data(500, 10)
+        sampler = ImportanceSampling(k=10, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert len(set(idx)) == len(idx)
+
+    def test_deterministic(self):
+        data = _make_data(500, 10)
+        s1 = ImportanceSampling(k=10, seed=42)
+        s2 = ImportanceSampling(k=10, seed=42)
+        idx1 = s1.get_indices(data, fraction=0.5)
+        idx2 = s2.get_indices(data, fraction=0.5)
+        np.testing.assert_array_equal(idx1, idx2)
+
+    def test_sparse_upweighted(self):
+        data = _make_dense_sparse(n_dense=400, n_sparse=100, d=10, seed=0)
+        sampler = ImportanceSampling(k=10, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+
+        # Sparse points are indices 400..499
+        sparse_in_sample = np.sum(idx >= 400)
+        sparse_fraction_sample = sparse_in_sample / len(idx)
+        sparse_fraction_full = 100 / 500
+
+        # Density-inverse weighting should oversample sparse region
+        assert sparse_fraction_sample > sparse_fraction_full
+
+    def test_rejects_int_input(self):
+        sampler = ImportanceSampling(k=10, seed=42)
+        with pytest.raises(TypeError):
+            sampler.get_indices(500, fraction=0.5)
+
+    def test_sample_method(self):
+        data = _make_data(500, 10)
+        ds = MockDataset()
+        sampler = ImportanceSampling(k=10, seed=42)
+        emb_sub, ds_sub, idx = sampler.sample(data, ds, fraction=0.5)
+
+        assert emb_sub.shape == (250, 10)
+        assert len(idx) == 250
+        assert isinstance(ds_sub, MockDataset)
+
+
+# ---------------------------------------------------------------------------
+# TestKStarWeightedSampling
+# ---------------------------------------------------------------------------
+
+class TestKStarWeightedSampling:
+    def test_output_size(self):
+        data = _make_data(500, 10)
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert len(idx) == 250
+
+    def test_sorted_indices(self):
+        data = _make_data(500, 10)
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert np.all(np.diff(idx) >= 0)
+
+    def test_no_duplicates(self):
+        data = _make_data(500, 10)
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+        assert len(set(idx)) == len(idx)
+
+    def test_deterministic(self):
+        data = _make_data(500, 10)
+        s1 = KStarWeightedSampling(k_max=50, seed=42)
+        s2 = KStarWeightedSampling(k_max=50, seed=42)
+        idx1 = s1.get_indices(data, fraction=0.5)
+        idx2 = s2.get_indices(data, fraction=0.5)
+        np.testing.assert_array_equal(idx1, idx2)
+
+    def test_boundary_enrichment(self):
+        data = _make_two_clusters(n_per_cluster=300, d=10, seed=0)
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        idx = sampler.get_indices(data, fraction=0.5)
+
+        # Boundary region: points where |x_0 - 2.5| < 1.5
+        sampled_x0 = data[idx, 0]
+        full_x0 = data[:, 0]
+
+        boundary_in_sample = np.sum(np.abs(sampled_x0 - 2.5) < 1.5)
+        boundary_in_full = np.sum(np.abs(full_x0 - 2.5) < 1.5)
+
+        boundary_frac_sample = boundary_in_sample / len(idx)
+        boundary_frac_full = boundary_in_full / len(data)
+
+        # k* weighting should overrepresent boundary points
+        assert boundary_frac_sample > boundary_frac_full
+
+    def test_rejects_int_input(self):
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        with pytest.raises(TypeError):
+            sampler.get_indices(500, fraction=0.5)
+
+    def test_sample_method(self):
+        data = _make_data(500, 10)
+        ds = MockDataset()
+        sampler = KStarWeightedSampling(k_max=50, seed=42)
+        emb_sub, ds_sub, idx = sampler.sample(data, ds, fraction=0.5)
+
+        assert emb_sub.shape == (250, 10)
+        assert len(idx) == 250
+        assert isinstance(ds_sub, MockDataset)


### PR DESCRIPTION
## Summary
- `ImportanceSampling`: density-inverse weighting via kNN radius ($w_i \propto r_i^\alpha$). Upweights sparse regions, downweights dense clusters. Caps at 99th percentile to avoid outlier oversampling.
- `KStarWeightedSampling`: geometry-aware weighting via k* ($w_i \propto k_{\max} - k^*_i + 1$). Preserves manifold boundary points where local scaling law breaks. Reuses `_compute_kstar` from the mismatch ratio metric.

Both follow the `SamplingStrategy` protocol and are usable via Hydra config or the Python API.

## Motivation
For the subsampling experiment: testing whether density-aware (IS) vs geometry-aware (k*) subsampling differentially reduces DR embedding artifacts. IS targets density uniformity; k* targets boundary preservation — these are distinct objectives that our diagnostic separates.

## Test plan
- [x] `pytest tests/test_sampling_importance_kstar.py -v` — 14 tests
- [x] Sparse-upweighting verified for IS
- [x] Boundary enrichment verified for KS
- [x] Determinism, sorting, no-duplicates
- [x] Full suite: 434 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)