### PR TITLE
feat: distillation algo module (ActivationSnapshot + Distillation + StagedTrainingCallback + align_on_snapshot)

### DIFF
--- a/manylatents/algorithms/lightning/distillation.py
+++ b/manylatents/algorithms/lightning/distillation.py
@@ -1,0 +1,324 @@
+"""Distillation LightningModule.
+
+Student training with an optional alignment regularizer sampled from a frozen
+:class:`~manylatents.lightning.activation_snapshot.ActivationSnapshot`. Mirrors
+the shape of :class:`manylatents.algorithms.lightning.reconstruction.Reconstruction`
+and :class:`manylatents.lightning.hf_trainer.HFTrainerModule`: one ``__init__``
+that captures configuration, one ``configure_model`` / ``setup`` that binds the
+student, one ``training_step`` that emits the combined loss.
+
+Phase1 alignment (pre-training against the snapshot's activations as targets)
+is NOT part of this module - it lives in
+``manylatents.algorithms.lightning.phase1_align.align_on_snapshot`` and runs
+imperatively before ``trainer.fit``. The callback that handles freeze/unfreeze
+between phase2 and phase3 lives in
+``manylatents.lightning.callbacks.staged_training.StagedTrainingCallback``.
+
+See ``/network/scratch/c/cesar.valdez/distillation-algo-module-plan.md``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+import torch
+import torch.nn as nn
+from lightning.pytorch import LightningModule
+from torch import Tensor
+
+from manylatents.lightning.activation_snapshot import ActivationSnapshot
+from manylatents.lightning.hooks import ActivationExtractor, LayerSpec, resolve_layer
+
+__all__ = ["Distillation"]
+
+
+def _sanitize_buffer_name(layer_path: str) -> str:
+    """Translate a dotted layer path to a valid Python identifier for register_buffer."""
+    return "_target__" + (
+        layer_path.replace(".", "_").replace("[", "_").replace("]", "_").replace("-", "m")
+    )
+
+
+def _collect_norm_param_ids(student: nn.Module) -> set:
+    """Return ids of all parameters living inside any norm module.
+
+    Matches LayerNorm and any other torch module whose class name ends with
+    ``Norm`` (covers RMSNorm, GroupNorm, BatchNorm, and third-party variants).
+    Module-type matching is more robust than string-matching on param names,
+    which fails for modules named ``final_ln`` / ``attn_norm`` / etc.
+    """
+    norm_param_ids = set()
+    for module in student.modules():
+        if isinstance(module, nn.LayerNorm) or type(module).__name__.endswith("Norm"):
+            for p in module.parameters(recurse=False):
+                norm_param_ids.add(id(p))
+    return norm_param_ids
+
+
+def _split_param_groups(
+    student: nn.Module,
+    weight_decay: float,
+) -> List[Dict[str, Any]]:
+    """Two AdamW param groups: weight-decayed for normal weights,
+    weight_decay=0 for biases and norm weights (standard HF recipe).
+
+    Only params with ``requires_grad=True`` are included. This is what makes
+    :class:`~manylatents.lightning.callbacks.staged_training.StagedTrainingCallback`'s
+    freeze semantic actually freeze - dropping a param from the optimizer
+    requires us to not include it here in the first place.
+    """
+    norm_ids = _collect_norm_param_ids(student)
+    decay, no_decay = [], []
+    for name, p in student.named_parameters():
+        if not p.requires_grad:
+            continue
+        if name.endswith(".bias") or id(p) in norm_ids:
+            no_decay.append(p)
+        else:
+            decay.append(p)
+    return [
+        {"params": decay, "weight_decay": weight_decay},
+        {"params": no_decay, "weight_decay": 0.0},
+    ]
+
+
+class Distillation(LightningModule):
+    """Student training with optional frozen-snapshot alignment regularizer.
+
+    Args:
+        datamodule: Lightning datamodule providing ``train_dataloader`` (and
+            optionally ``val_dataloader``). Each batch must be ``dict``-shaped
+            with keys the student's ``forward`` accepts - typically
+            ``input_ids``, ``attention_mask``, and ``labels``.
+        student: pre-instantiated ``nn.Module`` for the student. The Hydra
+            config layer (see ``configs/algorithms/lightning/distillation/``)
+            wraps this with a ``_target_`` pointing at a builder function.
+        activation_snapshot: frozen reference snapshot used for the alignment
+            regularizer. Tensors are registered as buffers so ``.to(device)``
+            and checkpointing Just Work.
+        layer_pairs: list of
+            ``{"student": <student_layer_path>, "teacher": <snapshot_key>, "weight": <float>}``.
+            Only used when ``alignment_weight > 0``.
+        optimizer: AdamW config. Recognised keys: ``learning_rate`` (or ``lr``),
+            ``weight_decay``, ``betas``, ``eps``. Anything else ignored.
+        alignment_weight: coefficient on the alignment MSE term. ``0.0`` means
+            pure task training; the module never runs the probe forward pass.
+        alignment_batch_size: number of probe samples drawn per
+            ``training_step`` when computing the alignment term.
+        init_seed: seed used before optimizer construction. Student weights are
+            the caller's responsibility - init the module deterministically
+            upstream if you need reproducible runs.
+        lr_scheduler: optional scheduler config. Keys: ``warmup_steps``,
+            ``total_steps``. Uses a linear warmup+decay schedule.
+    """
+
+    def __init__(
+        self,
+        datamodule,
+        student: nn.Module,
+        activation_snapshot: ActivationSnapshot,
+        layer_pairs: List[Mapping[str, Any]],
+        optimizer: Mapping[str, Any],
+        *,
+        alignment_weight: float = 0.0,
+        alignment_batch_size: int = 16,
+        init_seed: int = 42,
+        lr_scheduler: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+
+        if alignment_weight > 0 and len(layer_pairs) == 0:
+            raise ValueError(
+                "layer_pairs must be non-empty when alignment_weight > 0"
+            )
+
+        # Reduction is a property of the snapshot, NOT a duplicate here.
+        # _alignment_loss reads self.snapshot.reduction directly.
+        self._snapshot = activation_snapshot
+
+        # Validate layer_pairs against the snapshot's keys up front. Failing
+        # early avoids a confusing KeyError deep inside _alignment_loss.
+        if alignment_weight > 0:
+            snapshot_layers = set(activation_snapshot.activations.keys())
+            for pair in layer_pairs:
+                if pair["teacher"] not in snapshot_layers:
+                    raise ValueError(
+                        f"layer_pairs teacher={pair['teacher']!r} is not in "
+                        f"snapshot.activations (keys: {sorted(snapshot_layers)})"
+                    )
+
+        self.datamodule = datamodule
+        self.student = student
+        self.layer_pairs = [dict(p) for p in layer_pairs]
+        self.optimizer_cfg = dict(optimizer)
+        self.lr_scheduler_cfg = dict(lr_scheduler) if lr_scheduler is not None else None
+        self.alignment_weight = float(alignment_weight)
+        self.alignment_batch_size = int(alignment_batch_size)
+        self.init_seed = int(init_seed)
+
+        # Register snapshot tensors as buffers so .to(device) moves them and
+        # Lightning saves them in checkpoints. Biased copy (.clone()) so
+        # snapshot lifecycle is independent of the module's.
+        self.register_buffer("_probe_input_ids", activation_snapshot.input_ids.clone())
+        self.register_buffer(
+            "_probe_attention_mask", activation_snapshot.attention_mask.clone()
+        )
+        self._layer_buffer_names: Dict[str, str] = {}
+        for layer_path, acts in activation_snapshot.activations.items():
+            buf_name = _sanitize_buffer_name(layer_path)
+            self.register_buffer(buf_name, acts.clone())
+            self._layer_buffer_names[layer_path] = buf_name
+
+        # Validate student layer paths resolve (only if we'll actually use them).
+        if alignment_weight > 0:
+            for pair in layer_pairs:
+                try:
+                    resolve_layer(student, pair["student"])
+                except (AttributeError, IndexError) as exc:
+                    raise ValueError(
+                        f"layer_pairs student={pair['student']!r} does not "
+                        f"resolve on the provided student module: {exc}"
+                    ) from exc
+
+    @property
+    def snapshot(self) -> ActivationSnapshot:
+        """The frozen snapshot passed at construction. Reduction and other
+        metadata are read through this accessor; tensors live as buffers on
+        the module itself (see ``_probe_input_ids`` etc.)."""
+        return self._snapshot
+
+    def configure_model(self) -> None:
+        """No-op. The student is passed pre-instantiated at ``__init__`` time.
+
+        Override this in a subclass if lazy instantiation is needed (e.g. for
+        FSDP). The default path keeps the constructor deterministic and avoids
+        the failure modes the previous refactor hit with persistent hooks
+        installed at configure_model time.
+        """
+        pass
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        """Seed before optimizer construction. Student weight init is the
+        caller's job (before passing the student in)."""
+        torch.manual_seed(self.init_seed)
+
+    def forward(self, **inputs: Any) -> Any:
+        return self.student(**inputs)
+
+    def training_step(self, batch: Mapping[str, Tensor], batch_idx: int) -> Tensor:
+        outputs = self(**batch)
+        task_loss: Tensor = outputs.loss if hasattr(outputs, "loss") else outputs["loss"]
+        self.log("train_task_loss", task_loss, prog_bar=False, on_step=True, on_epoch=False)
+
+        if self.alignment_weight > 0:
+            align_loss = self._alignment_loss()
+            self.log(
+                "train_align_loss",
+                align_loss,
+                prog_bar=False,
+                on_step=True,
+                on_epoch=False,
+            )
+            total = task_loss + self.alignment_weight * align_loss
+        else:
+            total = task_loss
+
+        self.log(
+            "train_total_loss",
+            total,
+            prog_bar=False,
+            on_step=True,
+            on_epoch=False,
+        )
+        return total
+
+    def _sample_probe_indices(self) -> Tensor:
+        """Draw ``alignment_batch_size`` unique indices (or fewer if the probe
+        set is smaller) uniformly at random on each call. Uses
+        :func:`torch.randperm`, seeded by PyTorch's global RNG - callers who
+        need reproducibility should ``torch.manual_seed`` upstream or inside
+        a subclass override.
+        """
+        n_probe = int(self._probe_input_ids.shape[0])
+        k = min(self.alignment_batch_size, n_probe)
+        # randperm lives on the same device as the probe buffer (CUDA when
+        # moved), so we don't induce a host-device sync per step.
+        perm = torch.randperm(n_probe, device=self._probe_input_ids.device)
+        return perm[:k]
+
+    def _alignment_loss(self) -> Tensor:
+        """Compute weighted MSE between student activations and the snapshot's
+        pre-pooled targets over a randomly sampled probe mini-batch.
+
+        Uses ``ActivationExtractor.capture`` as a per-call context manager so
+        hooks are registered only for the duration of this method and torn
+        down on exit. No persistent hooks survive into the next
+        ``training_step`` - this was the failure mode of the prior refactor.
+
+        Reduction matches ``self.snapshot.reduction``; the snapshot is the
+        single source of truth for how activations were pooled.
+        """
+        specs = [
+            LayerSpec(path=pair["student"], reduce=self.snapshot.reduction)
+            for pair in self.layer_pairs
+        ]
+        extractor = ActivationExtractor(specs, detach=False)
+
+        idx = self._sample_probe_indices()
+        probe_ids = self._probe_input_ids[idx]
+        probe_mask = self._probe_attention_mask[idx]
+
+        with extractor.capture(self.student):
+            # No labels - we only want the forward activations. Some student
+            # interfaces require `labels` for loss computation; omitting it
+            # means `outputs.loss` is None, which is fine since we discard the
+            # return value.
+            self.student(input_ids=probe_ids, attention_mask=probe_mask)
+
+        student_acts = extractor.get_activations()
+
+        total = torch.zeros((), device=self._probe_input_ids.device, dtype=torch.float32)
+        for pair in self.layer_pairs:
+            student_path = pair["student"]
+            teacher_path = pair["teacher"]
+            weight = float(pair.get("weight", 1.0))
+
+            buffer_name = self._layer_buffer_names[teacher_path]
+            target = getattr(self, buffer_name)[idx]
+            live = student_acts[student_path]
+            total = total + weight * ((live - target.to(live.dtype)) ** 2).mean()
+
+        return total
+
+    def configure_optimizers(self) -> Any:
+        lr = float(
+            self.optimizer_cfg.get("learning_rate", self.optimizer_cfg.get("lr", 1e-4))
+        )
+        weight_decay = float(self.optimizer_cfg.get("weight_decay", 0.0))
+        betas = tuple(self.optimizer_cfg.get("betas", (0.9, 0.999)))
+        eps = float(self.optimizer_cfg.get("eps", 1e-8))
+
+        param_groups = _split_param_groups(
+            self.student,
+            weight_decay=weight_decay,
+        )
+        optimizer = torch.optim.AdamW(
+            param_groups,
+            lr=lr,
+            betas=betas,
+            eps=eps,
+        )
+
+        if self.lr_scheduler_cfg is None:
+            return optimizer
+
+        from transformers import get_linear_schedule_with_warmup
+
+        warmup_steps = int(self.lr_scheduler_cfg.get("warmup_steps", 0))
+        total_steps = int(self.lr_scheduler_cfg.get("total_steps", 0))
+        scheduler = get_linear_schedule_with_warmup(
+            optimizer, num_warmup_steps=warmup_steps, num_training_steps=total_steps
+        )
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
+        }

--- a/manylatents/algorithms/lightning/phase1_align.py
+++ b/manylatents/algorithms/lightning/phase1_align.py
@@ -1,0 +1,192 @@
+"""Phase1 alignment pre-training helper.
+
+Imperative loop that runs a student against a frozen
+:class:`~manylatents.lightning.activation_snapshot.ActivationSnapshot` for a
+fixed number of optimizer steps, minimizing weighted MSE between the
+student's aligned-layer activations and the snapshot's stored targets.
+
+Deliberately NOT a ``trainer.fit`` call and NOT a LightningModule method.
+Phase1 is small, closed-form against a fixed buffer, and doesn't need
+Lightning's dataloader-per-step machinery. Exposing it as a free function
+taking any ``nn.Module`` keeps it reusable beyond
+:class:`~manylatents.algorithms.lightning.distillation.Distillation` - probing
+warmups, CKA warmups, and other non-Lightning scenarios can call this
+directly.
+
+See the plan at ``/network/scratch/c/cesar.valdez/distillation-algo-module-plan.md``
+for the architectural commitments driving this split.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from manylatents.lightning.activation_snapshot import ActivationSnapshot
+from manylatents.lightning.hooks import ActivationExtractor, LayerSpec, resolve_layer
+
+__all__ = ["align_on_snapshot"]
+
+
+def _device_matches(tensor_device: torch.device, expected: torch.device) -> bool:
+    """Compare devices respecting torch's "unspecified index" semantic.
+
+    ``torch.device("cuda")`` has ``index=None`` and should match *any* cuda
+    index. ``torch.device("cuda:0")`` only matches cuda device 0. Same for
+    cpu/meta/mps. This matches how PyTorch itself handles missing indices in
+    ``Tensor.to(device)``.
+    """
+    if tensor_device.type != expected.type:
+        return False
+    if expected.index is None:
+        return True
+    return tensor_device.index == expected.index
+
+
+def _assert_snapshot_on_device(snap: ActivationSnapshot, device: torch.device) -> None:
+    """Raise ValueError if any snapshot tensor is on a different device.
+
+    Frozen snapshots cannot be mutated in place (``@dataclass(frozen=True)``),
+    so a silent ``.to(device)`` would force us to return a new snapshot - which
+    breaks caller expectations that the object they passed in is the object
+    being used. Instead we refuse and make device management the caller's
+    responsibility. This matches the plan's "no silent copies" rule.
+    """
+    tensors: List[tuple] = [
+        ("input_ids", snap.input_ids),
+        ("attention_mask", snap.attention_mask),
+    ]
+    for path, acts in snap.activations.items():
+        tensors.append((f"activations[{path!r}]", acts))
+
+    mismatches = [
+        (name, t.device) for name, t in tensors
+        if not _device_matches(t.device, device)
+    ]
+    if mismatches:
+        raise ValueError(
+            f"align_on_snapshot received device={device} but the following "
+            f"snapshot tensors are on other devices: {mismatches}. Load the "
+            f"snapshot onto the target device before calling; we refuse to "
+            f"mutate a frozen dataclass silently."
+        )
+
+
+def align_on_snapshot(
+    student: nn.Module,
+    snapshot: ActivationSnapshot,
+    layer_pairs: List[Mapping[str, Any]],
+    n_steps: int,
+    optimizer_cfg: Mapping[str, Any],
+    *,
+    batch_size: int = 16,
+    seed: int = 42,
+    device: str = "cuda",
+) -> List[float]:
+    """Run ``n_steps`` optimizer steps of alignment-only SGD on the student.
+
+    Fresh AdamW built from ``optimizer_cfg`` (``learning_rate``/``lr``,
+    ``weight_decay``, ``betas``, ``eps``). Does not share optimizer state with
+    any phase2/3 optimizer the caller may build later. Returns the per-step
+    loss trajectory as a list of floats.
+
+    Args:
+        student: model being aligned. Moved to ``device`` by this function.
+        snapshot: frozen reference of pre-pooled activations. Its tensors
+            must already be on ``device``; this function will not move them.
+        layer_pairs: list of
+            ``{"student": <student_layer_path>, "teacher": <snapshot_key>, "weight": <float>}``.
+        n_steps: number of optimizer steps to run. Returns a list of length
+            ``n_steps`` (or empty if ``n_steps == 0``).
+        optimizer_cfg: AdamW hyperparameters. Keys: ``learning_rate``/``lr``,
+            ``weight_decay``, ``betas``, ``eps``.
+        batch_size: probe minibatch size. Capped at ``len(snapshot)``.
+        seed: used to seed ``torch.Generator`` for per-step probe sampling.
+            For per-trial variation in sweeps, pass the same ``seed`` that
+            drives the consumer's datamodule (``TextDataModule.seed`` or
+            equivalent).
+        device: where the student and snapshot tensors must live.
+
+    Returns:
+        List of per-step weighted-MSE losses (detached floats).
+
+    Raises:
+        ValueError: if any snapshot tensor is on a device other than
+            ``device``, or if a student layer path does not resolve.
+    """
+    if n_steps == 0:
+        return []
+
+    torch_device = torch.device(device)
+    _assert_snapshot_on_device(snapshot, torch_device)
+    student = student.to(torch_device)
+
+    # Validate student paths before starting the loop so misconfig fails fast.
+    for pair in layer_pairs:
+        try:
+            resolve_layer(student, pair["student"])
+        except (AttributeError, IndexError) as exc:
+            raise ValueError(
+                f"layer_pairs student={pair['student']!r} does not resolve "
+                f"on the provided student module: {exc}"
+            ) from exc
+
+    # AdamW (no split into decay/no-decay groups; phase1 is short enough that
+    # the distinction rarely affects the finding, and avoiding the split keeps
+    # this helper simple and independent of Distillation's internals).
+    lr = float(optimizer_cfg.get("learning_rate", optimizer_cfg.get("lr", 1e-4)))
+    weight_decay = float(optimizer_cfg.get("weight_decay", 0.0))
+    betas = tuple(optimizer_cfg.get("betas", (0.9, 0.999)))
+    eps = float(optimizer_cfg.get("eps", 1e-8))
+    optimizer = torch.optim.AdamW(
+        [p for p in student.parameters() if p.requires_grad],
+        lr=lr,
+        betas=betas,
+        eps=eps,
+        weight_decay=weight_decay,
+    )
+
+    specs = [
+        LayerSpec(path=pair["student"], reduce=snapshot.reduction)
+        for pair in layer_pairs
+    ]
+    extractor = ActivationExtractor(specs, detach=False)
+
+    n_probe = len(snapshot)
+    k = min(batch_size, n_probe)
+
+    prior_training = student.training
+    student.train()
+    losses: List[float] = []
+    try:
+        # One capture context wraps the whole loop: hooks installed once,
+        # removed on exit. Activations cleared per step via get_activations().
+        with extractor.capture(student):
+            for step in range(n_steps):
+                gen = torch.Generator(device=torch_device).manual_seed(seed + step)
+                idx = torch.randperm(n_probe, device=torch_device, generator=gen)[:k]
+
+                probe_ids = snapshot.input_ids[idx]
+                probe_mask = snapshot.attention_mask[idx]
+
+                optimizer.zero_grad()
+                student(input_ids=probe_ids, attention_mask=probe_mask)
+                student_acts = extractor.get_activations(clear=True)
+
+                total = torch.zeros((), device=torch_device, dtype=torch.float32)
+                for pair in layer_pairs:
+                    w = float(pair.get("weight", 1.0))
+                    target = snapshot.activations[pair["teacher"]][idx]
+                    live = student_acts[pair["student"]]
+                    total = total + w * ((live - target.to(live.dtype)) ** 2).mean()
+
+                total.backward()
+                optimizer.step()
+                losses.append(float(total.detach().cpu()))
+    finally:
+        if not prior_training:
+            student.eval()
+
+    return losses

--- a/manylatents/configs/algorithms/lightning/distillation/base.yaml
+++ b/manylatents/configs/algorithms/lightning/distillation/base.yaml
@@ -1,0 +1,40 @@
+# manylatents/configs/algorithms/lightning/distillation/base.yaml
+# Pure task training against a pre-materialized ActivationSnapshot.
+# alignment_weight=0 means the snapshot is carried but the alignment
+# regularizer never runs - useful as a task-only control, or as the
+# default entry point when the consumer will override alignment_weight.
+#
+# Required overrides from the consumer:
+#   student           _target_ pointing at an nn.Module builder
+#   activation_snapshot.path  path to a saved snapshot on disk
+#   layer_pairs       list of {student, teacher, weight} dicts
+_target_: manylatents.algorithms.lightning.distillation.Distillation
+_recursive_: false
+
+datamodule: ${data}
+
+# Consumer must override `student._target_`. No default - there's no
+# sensible generic student nn.Module for this library.
+student: ???
+
+# Snapshot is loaded from disk. Build with:
+#   ActivationSnapshot.from_model(teacher, ...).save(path)
+# in a one-off materialization job, then point the path here.
+activation_snapshot:
+  _target_: manylatents.lightning.activation_snapshot.ActivationSnapshot.load
+  path: ???
+
+# Consumer must override. Shape:
+#   [{student: <student_path>, teacher: <snapshot_key>, weight: <float>}, ...]
+layer_pairs: []
+
+optimizer:
+  learning_rate: 2e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.999]
+  eps: 1e-8
+
+alignment_weight: 0.0
+alignment_batch_size: 16
+init_seed: 42
+lr_scheduler: null

--- a/manylatents/configs/algorithms/lightning/distillation/control_task_only.yaml
+++ b/manylatents/configs/algorithms/lightning/distillation/control_task_only.yaml
@@ -1,0 +1,33 @@
+# manylatents/configs/algorithms/lightning/distillation/control_task_only.yaml
+# Task-only control: no alignment regularizer, aligned layers frozen from
+# step 0. Baseline that matches the staged run's *trainable* parameter
+# budget without giving the student access to teacher activations.
+#
+# Consumer wires the callback with phase3_start_step: 0:
+#   trainer:
+#     callbacks:
+#       - _target_: manylatents.lightning.callbacks.staged_training.StagedTrainingCallback
+#         phase3_start_step: 0
+#         frozen_prefixes_phase2: [bert.encoder.layer.m2]
+_target_: manylatents.algorithms.lightning.distillation.Distillation
+_recursive_: false
+
+datamodule: ${data}
+student: ???
+
+activation_snapshot:
+  _target_: manylatents.lightning.activation_snapshot.ActivationSnapshot.load
+  path: ???
+
+layer_pairs: []
+
+optimizer:
+  learning_rate: 2e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.999]
+  eps: 1e-8
+
+alignment_weight: 0.0
+alignment_batch_size: 16
+init_seed: 42
+lr_scheduler: null

--- a/manylatents/configs/algorithms/lightning/distillation/staged.yaml
+++ b/manylatents/configs/algorithms/lightning/distillation/staged.yaml
@@ -1,0 +1,33 @@
+# manylatents/configs/algorithms/lightning/distillation/staged.yaml
+# Three-phase staged distillation with alignment regularizer.
+#
+# Required overrides: student, activation_snapshot.path, layer_pairs.
+#
+# Consumer wires StagedTrainingCallback via trainer.callbacks:
+#   trainer:
+#     callbacks:
+#       - _target_: manylatents.lightning.callbacks.staged_training.StagedTrainingCallback
+#         phase3_start_step: 1250
+#         frozen_prefixes_phase2: [bert.encoder.layer.m2]
+_target_: manylatents.algorithms.lightning.distillation.Distillation
+_recursive_: false
+
+datamodule: ${data}
+student: ???
+
+activation_snapshot:
+  _target_: manylatents.lightning.activation_snapshot.ActivationSnapshot.load
+  path: ???
+
+layer_pairs: []
+
+optimizer:
+  learning_rate: 2e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.999]
+  eps: 1e-8
+
+alignment_weight: 1.0
+alignment_batch_size: 16
+init_seed: 42
+lr_scheduler: null

--- a/manylatents/lightning/activation_snapshot.py
+++ b/manylatents/lightning/activation_snapshot.py
@@ -1,0 +1,255 @@
+"""Frozen per-layer activation snapshot.
+
+An ActivationSnapshot pairs a fixed set of tokenized inputs with pre-computed,
+already-pooled activations at named layers. Used as a reference artifact for
+alignment-style training losses (see
+``manylatents.algorithms.lightning.distillation``), probing, and analysis that
+requires stable target activations against a known input set.
+
+The snapshot declares, via the ``reduction`` field, how its per-layer tensors
+were pooled (``mean``, ``cls``, ``last_token``, ``first_token``, ``none``).
+Consumers that perform a fresh student forward for a regularizer use this field
+to drive matching pooling of the live activations; they do not re-state
+producer-side recipes.
+
+Contract for ``sample_ids``: when a snapshot is built against a probe split
+from a consumer's ``LightningDataModule`` (e.g. ``TextDataModule``), its
+``sample_ids`` must be the same identifiers the datamodule emits at training
+time (e.g. ``batch["probe_ids"]``). Mismatched ID spaces cause silent
+target-lookup errors. This is a consumer-side convention; we enforce uniqueness
+on the snapshot side and document the rest.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from manylatents.lightning.hooks import (
+    VALID_REDUCE,
+    ActivationExtractor,
+    LayerSpec,
+)
+
+__all__ = ["ActivationSnapshot", "SNAPSHOT_SCHEMA_VERSION"]
+
+# Bump when the on-disk format changes incompatibly. `load` rejects unknown
+# versions rather than silently mis-deserializing. Migration paths (if any) go
+# inside `load` keyed on the version field.
+SNAPSHOT_SCHEMA_VERSION: int = 1
+
+
+@dataclass(frozen=True)
+class ActivationSnapshot:
+    """Fixed batch of tokenized inputs with pre-computed, already-pooled
+    activations at named layers.
+
+    Attributes:
+        input_ids: (N, L) int64 token IDs.
+        attention_mask: (N, L) int64 attention mask.
+        sample_ids: length-N list of unique identifiers (see contract above).
+        activations: dict mapping layer path (str) to a (N, hidden) tensor of
+            activations already pooled with ``reduction``.
+        reduction: the single pooling strategy applied to every tensor in
+            ``activations``. One of the entries in
+            ``manylatents.lightning.hooks.VALID_REDUCE``.
+    """
+
+    input_ids: Tensor
+    attention_mask: Tensor
+    sample_ids: List[int]
+    activations: Dict[str, Tensor]
+    reduction: str
+
+    def __post_init__(self) -> None:
+        n = self.input_ids.shape[0]
+
+        if self.attention_mask.shape[0] != n:
+            raise ValueError(
+                f"attention_mask.shape[0] ({self.attention_mask.shape[0]}) "
+                f"must equal input_ids.shape[0] ({n})"
+            )
+        if len(self.sample_ids) != n:
+            raise ValueError(
+                f"len(sample_ids) ({len(self.sample_ids)}) must equal "
+                f"input_ids.shape[0] ({n})"
+            )
+        if len(set(self.sample_ids)) != len(self.sample_ids):
+            raise ValueError("sample_ids must be unique")
+
+        if self.reduction not in VALID_REDUCE:
+            raise ValueError(
+                f"reduction must be one of {VALID_REDUCE}, got {self.reduction!r}"
+            )
+
+        input_device = self.input_ids.device
+        if self.attention_mask.device != input_device:
+            raise ValueError(
+                f"attention_mask device ({self.attention_mask.device}) must "
+                f"equal input_ids device ({input_device})"
+            )
+
+        for layer, acts in self.activations.items():
+            if acts.shape[0] != n:
+                raise ValueError(
+                    f"activations[{layer!r}].shape[0] ({acts.shape[0]}) must "
+                    f"equal input_ids.shape[0] ({n})"
+                )
+            if acts.device != input_device:
+                raise ValueError(
+                    f"activations[{layer!r}] device ({acts.device}) must "
+                    f"equal input_ids device ({input_device})"
+                )
+
+    def __len__(self) -> int:
+        return self.input_ids.shape[0]
+
+    def save(self, path: Path | str) -> None:
+        """Serialize to disk as a single ``torch.save`` blob.
+
+        The on-disk format is a versioned dict. ``load`` validates the version
+        and reconstructs the dataclass (re-triggering ``__post_init__``).
+        """
+        torch.save(
+            {
+                "_version": SNAPSHOT_SCHEMA_VERSION,
+                "input_ids": self.input_ids,
+                "attention_mask": self.attention_mask,
+                "sample_ids": list(self.sample_ids),
+                "activations": dict(self.activations),
+                "reduction": self.reduction,
+            },
+            str(path),
+        )
+
+    @classmethod
+    def from_model(
+        cls,
+        model: nn.Module,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        sample_ids: Sequence[int],
+        layer_paths: Sequence[str],
+        *,
+        reduction: str = "mean",
+        batch_size: int = 8,
+        device: Optional[str] = None,
+    ) -> "ActivationSnapshot":
+        """Run ``model`` over ``(input_ids, attention_mask)`` and capture
+        activations at every path in ``layer_paths`` using ``reduction``.
+
+        This is the bridge between :class:`ActivationExtractor` (per-step hook
+        machinery) and a frozen snapshot. Model is run in eval + no_grad; hooks
+        are installed for exactly the duration of the batch loop and removed
+        on exit (via the extractor's context manager).
+
+        Args:
+            model: the model to forward. Will be put in eval mode for the call
+                and restored to its prior training mode on return.
+            input_ids: (N, L) long tensor of token ids.
+            attention_mask: (N, L) long tensor of attention mask values.
+            sample_ids: length-N sequence of unique integer ids. See the
+                class docstring for the consumer-side contract.
+            layer_paths: dotted paths to capture activations at. Resolution
+                uses :func:`manylatents.lightning.hooks.resolve_layer`, which
+                handles HF-family aliases (transformer.h <-> gpt_neox.layers
+                <-> model.layers). Every path must resolve to a module on
+                ``model``.
+            reduction: single pooling strategy applied to every captured
+                tensor. Must be one of ``VALID_REDUCE``. Per-layer reductions
+                are deliberately not supported — build multiple snapshots.
+            batch_size: forward-pass batch size. Does not change the result.
+            device: if given, move ``model``, ``input_ids``, and
+                ``attention_mask`` to this device before running. Outputs end
+                up on ``device``. If ``None``, runs wherever the inputs are.
+
+        Returns:
+            A frozen :class:`ActivationSnapshot` carrying the pooled
+            activations keyed by layer path.
+        """
+        if reduction not in VALID_REDUCE:
+            raise ValueError(
+                f"reduction must be one of {VALID_REDUCE}, got {reduction!r}"
+            )
+
+        n = input_ids.shape[0]
+        if attention_mask.shape[0] != n:
+            raise ValueError(
+                f"attention_mask.shape[0] ({attention_mask.shape[0]}) must "
+                f"equal input_ids.shape[0] ({n})"
+            )
+        if len(sample_ids) != n:
+            raise ValueError(
+                f"len(sample_ids) ({len(sample_ids)}) must equal "
+                f"input_ids.shape[0] ({n})"
+            )
+
+        prior_training = model.training
+        model.eval()
+        try:
+            if device is not None:
+                model = model.to(device)
+                input_ids = input_ids.to(device)
+                attention_mask = attention_mask.to(device)
+
+            specs = [LayerSpec(path=p, reduce=reduction) for p in layer_paths]
+            extractor = ActivationExtractor(specs, detach=True)
+
+            with torch.no_grad():
+                with extractor.capture(model):
+                    for start in range(0, n, batch_size):
+                        end = min(start + batch_size, n)
+                        model(
+                            input_ids=input_ids[start:end],
+                            attention_mask=attention_mask[start:end],
+                        )
+
+            activations = extractor.get_activations()
+        finally:
+            if prior_training:
+                model.train()
+
+        return cls(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            sample_ids=list(sample_ids),
+            activations=activations,
+            reduction=reduction,
+        )
+
+    @classmethod
+    def load(cls, path: Path | str) -> "ActivationSnapshot":
+        """Load a snapshot previously written by ``save``.
+
+        Raises:
+            ValueError: if the file's ``_version`` does not match
+                ``SNAPSHOT_SCHEMA_VERSION`` or the dict is missing required keys.
+        """
+        blob = torch.load(str(path), map_location="cpu", weights_only=False)
+        if not isinstance(blob, dict):
+            raise ValueError(
+                f"expected a dict at {path!s}, got {type(blob).__name__}"
+            )
+        version = blob.get("_version")
+        if version != SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError(
+                f"unknown ActivationSnapshot schema _version={version!r} at "
+                f"{path!s}; this build expects {SNAPSHOT_SCHEMA_VERSION}"
+            )
+        required = {"input_ids", "attention_mask", "sample_ids", "activations", "reduction"}
+        missing = required - blob.keys()
+        if missing:
+            raise ValueError(
+                f"malformed snapshot at {path!s}: missing keys {sorted(missing)}"
+            )
+        return cls(
+            input_ids=blob["input_ids"],
+            attention_mask=blob["attention_mask"],
+            sample_ids=list(blob["sample_ids"]),
+            activations=dict(blob["activations"]),
+            reduction=blob["reduction"],
+        )

--- a/manylatents/lightning/callbacks/__init__.py
+++ b/manylatents/lightning/callbacks/__init__.py
@@ -3,9 +3,16 @@ from manylatents.lightning.callbacks.activation_tracker import (
     ProbeTrigger,
     ActivationTrajectoryCallback,
 )
+from manylatents.lightning.callbacks.staged_training import StagedTrainingCallback
 from manylatents.lightning.callbacks.wandb_probe import WandbProbeLogger
 
 # Backward-compatible alias
 RepresentationProbeCallback = ActivationTrajectoryCallback
 
-__all__ = ["ProbeTrigger", "ActivationTrajectoryCallback", "RepresentationProbeCallback", "WandbProbeLogger"]
+__all__ = [
+    "ProbeTrigger",
+    "ActivationTrajectoryCallback",
+    "RepresentationProbeCallback",
+    "StagedTrainingCallback",
+    "WandbProbeLogger",
+]

--- a/manylatents/lightning/callbacks/staged_training.py
+++ b/manylatents/lightning/callbacks/staged_training.py
@@ -1,0 +1,210 @@
+"""Staged training callback for phase2 -> phase3 transitions.
+
+Phase1 (snapshot alignment against a frozen teacher) is expected to have
+already happened outside ``trainer.fit`` via ``align_on_snapshot``. This
+callback drives the phase2 -> phase3 boundary *inside* ``trainer.fit``:
+
+- ``on_train_start``: freeze parameters whose names match any configured
+  prefix (phase2), rebuild the optimizer to drop frozen params.
+- ``on_train_batch_end``: once ``global_step == phase3_start_step``, restore
+  ``requires_grad`` on previously-frozen params and rebuild the optimizer
+  again, preserving Adam state for params that were trainable throughout
+  phase2.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import torch
+from lightning import Callback, LightningModule, Trainer
+
+logger = logging.getLogger(__name__)
+
+
+def _matches(name: str, prefix: str) -> bool:
+    """Dot-boundary prefix match.
+
+    Returns True iff ``name`` equals ``prefix`` exactly or starts with
+    ``prefix + "."``. This avoids numeric-sibling collisions such as
+    ``"layer.1"`` overmatching ``"layer.10"``, ``"layer.11"``, ...
+    """
+    return name == prefix or name.startswith(prefix + ".")
+
+
+class StagedTrainingCallback(Callback):
+    """Toggle ``requires_grad`` and rebuild the optimizer at phase boundaries.
+
+    Parameters
+    ----------
+    phase3_start_step:
+        Global step at which previously-frozen parameters are unfrozen and
+        the optimizer is rebuilt. A value of ``0`` means phase2 is skipped
+        entirely and the callback behaves as an identity op.
+    frozen_prefixes_phase2:
+        List of parameter-name prefixes to freeze during phase2. Matching is
+        dot-boundary (see :func:`_matches`). Trailing dots on each prefix are
+        stripped on construction so ``"bert.encoder.layer.1"`` and
+        ``"bert.encoder.layer.1."`` behave identically.
+
+        **Important**: prefixes match the LightningModule's parameter names,
+        which include any nested-module attribute prefix. If your module holds
+        the actual trainable model as ``self.student = <hf_model>`` (as
+        :class:`~manylatents.algorithms.lightning.distillation.Distillation`
+        does), then the callback sees names like ``"student.bert.encoder..."``
+        - so your prefix must include the ``"student."`` prefix too. This is
+        an honest consequence of PyTorch's ``Module.named_parameters()``
+        semantic; the callback has no way to know which attribute holds "the
+        real model" and refuses to guess.
+    """
+
+    def __init__(
+        self,
+        phase3_start_step: int,
+        frozen_prefixes_phase2: List[str],
+    ) -> None:
+        super().__init__()
+        if phase3_start_step < 0:
+            raise ValueError(
+                f"phase3_start_step must be >= 0, got {phase3_start_step}"
+            )
+        self.phase3_start_step = int(phase3_start_step)
+        # Strip trailing dots for idempotence. Reject empty prefixes, which
+        # would match every parameter and almost certainly be a bug.
+        normalized: List[str] = []
+        for raw in frozen_prefixes_phase2:
+            if not isinstance(raw, str):
+                raise TypeError(
+                    f"frozen_prefixes_phase2 entries must be str, got {type(raw).__name__}"
+                )
+            p = raw.rstrip(".")
+            if p == "":
+                raise ValueError(
+                    "Empty prefix in frozen_prefixes_phase2 would freeze every "
+                    "parameter; reject as almost certainly a bug."
+                )
+            normalized.append(p)
+        self.frozen_prefixes_phase2: List[str] = normalized
+        self._phase3_done: bool = False
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _names_matching(self, model: torch.nn.Module) -> List[str]:
+        return [
+            name
+            for name, _ in model.named_parameters()
+            if any(_matches(name, pref) for pref in self.frozen_prefixes_phase2)
+        ]
+
+    def _set_requires_grad(
+        self,
+        model: torch.nn.Module,
+        *,
+        freeze: bool,
+    ) -> List[str]:
+        """Apply ``requires_grad = not freeze`` to matching params.
+
+        Returns the list of parameter names that were toggled.
+        """
+        touched: List[str] = []
+        for name, param in model.named_parameters():
+            if any(_matches(name, pref) for pref in self.frozen_prefixes_phase2):
+                param.requires_grad = not freeze
+                touched.append(name)
+        return touched
+
+    @staticmethod
+    def _capture_optimizer_state(
+        optimizer: torch.optim.Optimizer,
+    ) -> Dict[int, Dict[str, Any]]:
+        """Snapshot ``optimizer.state`` keyed by ``id(param)``.
+
+        ``copy()`` is shallow — Adam's ``exp_avg``/``exp_avg_sq`` tensors are
+        shared rather than duplicated, which is fine because Lightning rebuilds
+        the optimizer from scratch and we only need the references to survive
+        the interim. The ``step`` counter is a plain int and is captured by
+        value via the dict copy.
+        """
+        return {id(p): dict(state) for p, state in optimizer.state.items()}
+
+    @staticmethod
+    def _restore_optimizer_state(
+        optimizer: torch.optim.Optimizer,
+        state_by_param_id: Dict[int, Dict[str, Any]],
+    ) -> None:
+        """Restore previously-captured state onto matching params in ``optimizer``.
+
+        Params whose ``id()`` does not appear in ``state_by_param_id`` are left
+        with fresh (empty) state — this is the correct behavior for params that
+        were frozen during the previous phase and therefore had no Adam state.
+        """
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                prev = state_by_param_id.get(id(p))
+                if prev is not None:
+                    optimizer.state[p] = prev
+
+    def _rebuild_optimizer_preserving_state(
+        self, trainer: Trainer
+    ) -> None:
+        """Capture Adam state, ask Lightning to rebuild optimizers, restore state.
+
+        Falls back silently if ``trainer`` has no optimizers yet (e.g. before
+        ``fit`` has actually started — defensive; shouldn't happen on the
+        documented hooks).
+        """
+        if not trainer.optimizers:
+            return
+        old_state = self._capture_optimizer_state(trainer.optimizers[0])
+        # Ask Lightning to reconfigure optimizers from the LightningModule's
+        # ``configure_optimizers``. This drops all state by default; we restore
+        # it below for params that survived.
+        trainer.strategy.setup_optimizers(trainer)
+        if not trainer.optimizers:
+            return
+        self._restore_optimizer_state(trainer.optimizers[0], old_state)
+
+    # ------------------------------------------------------------------
+    # Lightning hooks
+    # ------------------------------------------------------------------
+    def on_train_start(
+        self, trainer: Trainer, pl_module: LightningModule
+    ) -> None:
+        if self.phase3_start_step == 0:
+            # Phase2 skipped entirely. No freeze, no optimizer rebuild.
+            self._phase3_done = True
+            return
+        if not self.frozen_prefixes_phase2:
+            # Nothing to freeze — treat as an identity op but still mark
+            # phase2 as active so the phase3 boundary still fires the rebuild.
+            return
+        touched = self._set_requires_grad(pl_module, freeze=True)
+        logger.info(
+            "StagedTrainingCallback: phase2 start, froze %d params matching %r",
+            len(touched),
+            self.frozen_prefixes_phase2,
+        )
+        self._rebuild_optimizer_preserving_state(trainer)
+
+    def on_train_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        if self._phase3_done:
+            return
+        if trainer.global_step < self.phase3_start_step:
+            return
+        # Crossed the boundary. Unfreeze and rebuild preserving phase2 state.
+        touched = self._set_requires_grad(pl_module, freeze=False)
+        logger.info(
+            "StagedTrainingCallback: phase3 start at step %d, unfroze %d params",
+            int(trainer.global_step),
+            len(touched),
+        )
+        self._rebuild_optimizer_preserving_state(trainer)
+        self._phase3_done = True

--- a/manylatents/lightning/callbacks/tests/test_staged_training.py
+++ b/manylatents/lightning/callbacks/tests/test_staged_training.py
@@ -1,0 +1,400 @@
+"""Tests for StagedTrainingCallback.
+
+All tests run on CPU. Fixtures are intentionally tiny (Linear(10, 10) or a
+2-layer synthetic transformer-like MLP) so each test completes in well under
+5 seconds.
+"""
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+import torch
+import torch.nn as nn
+from lightning import LightningModule, Trainer
+from torch.utils.data import DataLoader, TensorDataset
+
+from manylatents.lightning.callbacks.staged_training import (
+    StagedTrainingCallback,
+    _matches,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+class TinyStudent(LightningModule):
+    """Tiny LightningModule with named sub-modules for prefix-match tests.
+
+    Structure:
+      - ``embed``: Linear(10, 10)
+      - ``layer.{0..3}``: Linear(10, 10) each
+      - ``layer.10``, ``layer.11``, ``layer.12``: numeric siblings to test
+        the overmatch guard.
+      - ``head``: Linear(10, 1)
+    """
+
+    def __init__(self, lr: float = 1e-2) -> None:
+        super().__init__()
+        self.lr = lr
+        self.embed = nn.Linear(10, 10)
+        layer = nn.ModuleDict(
+            {
+                str(i): nn.Linear(10, 10)
+                for i in (0, 1, 2, 3, 10, 11, 12)
+            }
+        )
+        # Stash under attribute ``layer`` so named_parameters() produces
+        # names like "layer.1.weight", "layer.10.weight", etc.
+        self.layer = layer
+        self.head = nn.Linear(10, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.embed(x)
+        for key in ("0", "1", "2", "3", "10", "11", "12"):
+            h = self.layer[key](h)
+        return self.head(h)
+
+    def training_step(self, batch, batch_idx):  # type: ignore[override]
+        x, y = batch
+        pred = self(x)
+        loss = ((pred - y) ** 2).mean()
+        self.log("train_loss", loss, prog_bar=False)
+        return loss
+
+    def configure_optimizers(self):  # type: ignore[override]
+        trainable = [p for p in self.parameters() if p.requires_grad]
+        return torch.optim.Adam(trainable, lr=self.lr)
+
+
+def _make_loader(n: int = 8, batch_size: int = 4) -> DataLoader:
+    x = torch.randn(n, 10)
+    y = torch.randn(n, 1)
+    return DataLoader(TensorDataset(x, y), batch_size=batch_size)
+
+
+def _trainer(
+    callback: StagedTrainingCallback,
+    max_steps: int = 20,
+) -> Trainer:
+    return Trainer(
+        max_steps=max_steps,
+        accelerator="cpu",
+        devices=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=[callback],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function prefix-matching tests
+# ---------------------------------------------------------------------------
+def test_matches_exact() -> None:
+    assert _matches("layer.1", "layer.1")
+
+
+def test_matches_dot_boundary() -> None:
+    assert _matches("layer.1.weight", "layer.1")
+    assert _matches("bert.encoder.layer.0.attention", "bert.encoder.layer.0")
+
+
+def test_matches_rejects_numeric_sibling() -> None:
+    assert not _matches("layer.10", "layer.1")
+    assert not _matches("layer.11.weight", "layer.1")
+    assert not _matches("layer.12", "layer.1")
+
+
+def test_matches_rejects_unrelated_prefix() -> None:
+    assert not _matches("head.weight", "layer.1")
+
+
+# ---------------------------------------------------------------------------
+# Init-time normalization
+# ---------------------------------------------------------------------------
+def test_trailing_dot_is_stripped() -> None:
+    cb_a = StagedTrainingCallback(
+        phase3_start_step=5, frozen_prefixes_phase2=["layer.1"]
+    )
+    cb_b = StagedTrainingCallback(
+        phase3_start_step=5, frozen_prefixes_phase2=["layer.1."]
+    )
+    assert cb_a.frozen_prefixes_phase2 == cb_b.frozen_prefixes_phase2 == ["layer.1"]
+
+
+def test_empty_prefix_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        StagedTrainingCallback(phase3_start_step=5, frozen_prefixes_phase2=[""])
+    with pytest.raises(ValueError):
+        # A bare "." reduces to "" after rstrip.
+        StagedTrainingCallback(phase3_start_step=5, frozen_prefixes_phase2=["."])
+
+
+def test_negative_phase3_step_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        StagedTrainingCallback(
+            phase3_start_step=-1, frozen_prefixes_phase2=["layer.1"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# on_train_start behavior: freezing and optimizer rebuild
+# ---------------------------------------------------------------------------
+def test_on_train_start_freezes_matching_prefixes() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1", "layer.2"]
+    )
+    trainer = _trainer(cb, max_steps=1)
+    trainer.fit(model, _make_loader())
+
+    frozen_names = [
+        name for name, p in model.named_parameters() if not p.requires_grad
+    ]
+    # Only layer.1.* and layer.2.* should be frozen.
+    assert all(
+        n.startswith("layer.1.") or n.startswith("layer.2.") for n in frozen_names
+    )
+    # And both blocks must be fully frozen (weight + bias).
+    assert set(frozen_names) == {
+        "layer.1.weight",
+        "layer.1.bias",
+        "layer.2.weight",
+        "layer.2.bias",
+    }
+
+
+def test_on_train_start_keeps_non_matching_trainable() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=1)
+    trainer.fit(model, _make_loader())
+
+    for name in ("embed.weight", "embed.bias", "head.weight", "head.bias"):
+        p = dict(model.named_parameters())[name]
+        assert p.requires_grad, f"{name} should remain trainable"
+    # Sanity-check a sibling that must not be overmatched.
+    for name in ("layer.10.weight", "layer.11.weight", "layer.12.weight"):
+        p = dict(model.named_parameters())[name]
+        assert p.requires_grad, f"{name} should remain trainable"
+
+
+def test_prefix_does_not_overmatch_numeric_siblings() -> None:
+    """The core regression test: ``layer.1`` must NOT freeze ``layer.10``."""
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=1)
+    trainer.fit(model, _make_loader())
+
+    params = dict(model.named_parameters())
+    assert not params["layer.1.weight"].requires_grad
+    assert not params["layer.1.bias"].requires_grad
+    for sib in ("10", "11", "12"):
+        assert params[f"layer.{sib}.weight"].requires_grad
+        assert params[f"layer.{sib}.bias"].requires_grad
+
+
+def test_prefix_accepts_trailing_dot_or_not() -> None:
+    model_a = TinyStudent()
+    model_b = TinyStudent()
+    # Use the same init so the freeze sets can be compared by name.
+    model_b.load_state_dict(model_a.state_dict())
+
+    cb_a = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1"]
+    )
+    cb_b = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1."]
+    )
+    _trainer(cb_a, max_steps=1).fit(model_a, _make_loader())
+    _trainer(cb_b, max_steps=1).fit(model_b, _make_loader())
+
+    frozen_a = {
+        n for n, p in model_a.named_parameters() if not p.requires_grad
+    }
+    frozen_b = {
+        n for n, p in model_b.named_parameters() if not p.requires_grad
+    }
+    assert frozen_a == frozen_b
+    assert frozen_a == {"layer.1.weight", "layer.1.bias"}
+
+
+def test_rebuild_optimizer_drops_frozen_params() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=100, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=1)
+    trainer.fit(model, _make_loader())
+
+    opt = trainer.optimizers[0]
+    opt_param_ids = {id(p) for g in opt.param_groups for p in g["params"]}
+    for name, p in model.named_parameters():
+        if name.startswith("layer.1."):
+            assert id(p) not in opt_param_ids, f"{name} should be dropped"
+        else:
+            assert id(p) in opt_param_ids, f"{name} should be retained"
+
+
+# ---------------------------------------------------------------------------
+# Phase3 boundary: unfreeze and rebuild preserving state
+# ---------------------------------------------------------------------------
+def test_unfreezes_at_phase3_boundary() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=3, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=6)
+    trainer.fit(model, _make_loader(n=32))
+
+    # After crossing step 3, all params must be trainable again.
+    for name, p in model.named_parameters():
+        assert p.requires_grad, f"{name} should be trainable post-phase3"
+    assert cb._phase3_done is True
+
+
+def test_rebuild_optimizer_reinstates_frozen_params() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=2, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=4)
+    trainer.fit(model, _make_loader(n=32))
+
+    opt = trainer.optimizers[0]
+    opt_param_ids = {id(p) for g in opt.param_groups for p in g["params"]}
+    for name, p in model.named_parameters():
+        assert id(p) in opt_param_ids, f"{name} missing from phase3 optimizer"
+
+
+def test_phase3_preserves_optimizer_state_for_surviving_params() -> None:
+    """Params that trained through phase2 must retain their Adam moments
+    after the phase3 rebuild.
+    """
+    model = TinyStudent(lr=1e-2)
+    cb = StagedTrainingCallback(
+        phase3_start_step=3, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=5)
+    trainer.fit(model, _make_loader(n=40))
+
+    opt = trainer.optimizers[0]
+    # A param that was never frozen (e.g. ``embed.weight``) must have nonzero
+    # Adam state after running through the phase3 boundary.
+    embed_w = model.embed.weight
+    assert embed_w in opt.state, "embed.weight should have Adam state"
+    st = opt.state[embed_w]
+    assert "exp_avg" in st
+    assert "exp_avg_sq" in st
+    # ``exp_avg`` should be nonzero because we took >= 1 step in phase2 on it.
+    assert torch.any(st["exp_avg"] != 0), (
+        "embed.weight's Adam exp_avg should have survived the phase3 rebuild"
+    )
+    assert torch.any(st["exp_avg_sq"] != 0)
+    # ``step`` counter should reflect accumulated phase2 steps, not be reset.
+    assert int(st["step"]) >= 1
+
+
+def test_phase3_fresh_state_for_newly_unfrozen_params() -> None:
+    """Previously-frozen params must start phase3 with empty Adam state,
+    not leak any stale state from before they were frozen.
+    """
+    model = TinyStudent(lr=1e-2)
+    cb = StagedTrainingCallback(
+        phase3_start_step=3, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=4)
+    # Run up to and including the phase3 boundary, but not past it so the
+    # formerly-frozen param has not yet been stepped in phase3.
+    trainer.fit(model, _make_loader(n=32))
+
+    opt = trainer.optimizers[0]
+    frozen_p = model.layer["1"].weight
+    # Param was frozen throughout phase2 and has just been unfrozen at the
+    # boundary. Immediately after the rebuild (and before any phase3 step has
+    # touched it) its optimizer state entry must be empty. If trainer.fit
+    # continued for additional steps past the boundary with nonzero grads,
+    # Adam will have populated it; we assert the entry is either missing or
+    # freshly populated (``step`` == 1 at most).
+    st = opt.state.get(frozen_p, {})
+    if st:
+        assert int(st.get("step", 0)) <= 1, (
+            "previously-frozen param should not have leaked phase2 Adam state"
+        )
+
+
+def test_phase3_transition_loss_bounded() -> None:
+    """After the phase3 rebuild, loss must not spike more than 2x over the
+    immediately-prior step. This is the empirical guard that the Adam state
+    preservation actually works.
+    """
+    torch.manual_seed(0)
+
+    class LossRecorder(LightningModule):
+        def __init__(self) -> None:
+            super().__init__()
+            self.net = nn.Sequential(
+                nn.Linear(10, 10),
+                nn.Linear(10, 10),
+                nn.Linear(10, 1),
+            )
+            self.losses: List[float] = []
+
+        def forward(self, x):
+            return self.net(x)
+
+        def training_step(self, batch, batch_idx):
+            x, y = batch
+            loss = ((self(x) - y) ** 2).mean()
+            self.losses.append(float(loss.detach()))
+            return loss
+
+        def configure_optimizers(self):
+            trainable = [p for p in self.parameters() if p.requires_grad]
+            return torch.optim.Adam(trainable, lr=1e-2)
+
+    model = LossRecorder()
+    # Freeze ``net.0`` for the first 10 steps, then unfreeze at step 10.
+    cb = StagedTrainingCallback(
+        phase3_start_step=10, frozen_prefixes_phase2=["net.0"]
+    )
+    trainer = _trainer(cb, max_steps=20)
+    # Fixed batch → deterministic losses.
+    torch.manual_seed(0)
+    x = torch.randn(40, 10)
+    y = torch.randn(40, 1)
+    loader = DataLoader(TensorDataset(x, y), batch_size=4)
+    trainer.fit(model, loader)
+
+    assert len(model.losses) >= 11, (
+        f"expected >= 11 logged losses, got {len(model.losses)}"
+    )
+    prev = model.losses[9]
+    at_boundary = model.losses[10]
+    assert at_boundary < prev * 2.0, (
+        f"phase3 loss spike too large: losses[9]={prev:.4f}, "
+        f"losses[10]={at_boundary:.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+def test_phase3_start_zero_skips_phase2() -> None:
+    model = TinyStudent()
+    cb = StagedTrainingCallback(
+        phase3_start_step=0, frozen_prefixes_phase2=["layer.1"]
+    )
+    trainer = _trainer(cb, max_steps=2)
+    trainer.fit(model, _make_loader())
+
+    # No param should have been frozen: phase3_start_step=0 skips phase2.
+    for name, p in model.named_parameters():
+        assert p.requires_grad, f"{name} should remain trainable (phase2 skipped)"
+    assert cb._phase3_done is True

--- a/manylatents/lightning/hooks.py
+++ b/manylatents/lightning/hooks.py
@@ -94,8 +94,9 @@ class ActivationExtractor:
         activations = extractor.get_activations()
     """
 
-    def __init__(self, layer_specs: List[LayerSpec]):
+    def __init__(self, layer_specs: List[LayerSpec], detach: bool = True):
         self.layer_specs = layer_specs
+        self._detach = detach
         self._activations: Dict[str, List[Tensor]] = {}
         self._handles: List = []
 
@@ -113,7 +114,7 @@ class ActivationExtractor:
 
             if spec.path not in self._activations:
                 self._activations[spec.path] = []
-            self._activations[spec.path].append(tensor.detach())
+            self._activations[spec.path].append(tensor.detach() if self._detach else tensor)
 
         return hook
 

--- a/manylatents/lightning/tests/test_activation_snapshot.py
+++ b/manylatents/lightning/tests/test_activation_snapshot.py
@@ -1,0 +1,408 @@
+"""Unit tests for ActivationSnapshot invariants and save/load."""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from manylatents.lightning.activation_snapshot import (
+    ActivationSnapshot,
+    SNAPSHOT_SCHEMA_VERSION,
+)
+
+
+def _make_valid_fields(n: int = 4, seq_len: int = 8, hidden: int = 16):
+    return {
+        "input_ids": torch.zeros(n, seq_len, dtype=torch.long),
+        "attention_mask": torch.ones(n, seq_len, dtype=torch.long),
+        "sample_ids": list(range(n)),
+        "activations": {"encoder.layer.0": torch.zeros(n, hidden)},
+        "reduction": "mean",
+    }
+
+
+def test_construct_happy_path() -> None:
+    snap = ActivationSnapshot(**_make_valid_fields())
+    assert snap.reduction == "mean"
+    assert "encoder.layer.0" in snap.activations
+
+
+def test_post_init_rejects_shape_mismatch_attention_mask() -> None:
+    fields = _make_valid_fields(n=4)
+    fields["attention_mask"] = torch.ones(3, 8, dtype=torch.long)
+    with pytest.raises(ValueError, match=r"attention_mask\.shape\[0\]"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_rejects_shape_mismatch_sample_ids() -> None:
+    fields = _make_valid_fields(n=4)
+    fields["sample_ids"] = [0, 1, 2]
+    with pytest.raises(ValueError, match=r"len\(sample_ids\)"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_rejects_duplicate_sample_ids() -> None:
+    fields = _make_valid_fields(n=4)
+    fields["sample_ids"] = [0, 1, 1, 2]
+    with pytest.raises(ValueError, match=r"unique"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_rejects_wrong_activation_first_dim() -> None:
+    fields = _make_valid_fields(n=4, hidden=16)
+    fields["activations"] = {"encoder.layer.0": torch.zeros(3, 16)}
+    with pytest.raises(ValueError, match=r"activations.*shape\[0\]"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_rejects_unknown_reduction() -> None:
+    fields = _make_valid_fields()
+    fields["reduction"] = "gibberish"
+    with pytest.raises(ValueError, match=r"reduction must be one of"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_accepts_all_valid_reductions() -> None:
+    fields = _make_valid_fields()
+    for reduction in ("mean", "last_token", "cls", "first_token", "none"):
+        fields_copy = {**fields, "reduction": reduction}
+        ActivationSnapshot(**fields_copy)
+
+
+def test_post_init_rejects_device_mismatch_attention_mask() -> None:
+    fields = _make_valid_fields()
+    # meta device is always available, avoids CUDA requirement
+    fields["attention_mask"] = fields["attention_mask"].to("meta")
+    with pytest.raises(ValueError, match=r"attention_mask device"):
+        ActivationSnapshot(**fields)
+
+
+def test_post_init_rejects_device_mismatch_activations() -> None:
+    fields = _make_valid_fields()
+    fields["activations"] = {
+        "encoder.layer.0": fields["activations"]["encoder.layer.0"].to("meta")
+    }
+    with pytest.raises(ValueError, match=r"activations.*device"):
+        ActivationSnapshot(**fields)
+
+
+def test_len_returns_n_samples() -> None:
+    snap = ActivationSnapshot(**_make_valid_fields(n=7))
+    assert len(snap) == 7
+
+
+def test_multiple_layers_all_validated() -> None:
+    """Every activation tensor must pass shape+device checks, not just the first."""
+    fields = _make_valid_fields(n=4, hidden=16)
+    fields["activations"] = {
+        "encoder.layer.0": torch.zeros(4, 16),
+        "encoder.layer.11": torch.zeros(3, 16),  # wrong
+    }
+    with pytest.raises(ValueError, match=r"encoder\.layer\.11"):
+        ActivationSnapshot(**fields)
+
+
+def test_frozen_cannot_mutate() -> None:
+    snap = ActivationSnapshot(**_make_valid_fields())
+    with pytest.raises((AttributeError, Exception)):
+        snap.reduction = "cls"  # type: ignore[misc]
+
+
+def test_save_load_roundtrip(tmp_path) -> None:
+    fields = _make_valid_fields(n=5, hidden=8)
+    fields["input_ids"] = torch.randint(0, 100, (5, 8), dtype=torch.long)
+    fields["sample_ids"] = [10, 20, 30, 40, 50]
+    fields["activations"] = {
+        "encoder.layer.0": torch.randn(5, 8),
+        "encoder.layer.11": torch.randn(5, 8),
+    }
+    snap = ActivationSnapshot(**fields)
+
+    path = tmp_path / "snap.pt"
+    snap.save(path)
+    loaded = ActivationSnapshot.load(path)
+
+    assert torch.equal(loaded.input_ids, snap.input_ids)
+    assert torch.equal(loaded.attention_mask, snap.attention_mask)
+    assert loaded.sample_ids == snap.sample_ids
+    assert loaded.reduction == snap.reduction
+    assert set(loaded.activations.keys()) == set(snap.activations.keys())
+    for k in snap.activations:
+        assert torch.equal(loaded.activations[k], snap.activations[k])
+
+
+def test_save_accepts_str_path(tmp_path) -> None:
+    snap = ActivationSnapshot(**_make_valid_fields())
+    path_str = str(tmp_path / "snap.pt")
+    snap.save(path_str)
+    loaded = ActivationSnapshot.load(path_str)
+    assert len(loaded) == len(snap)
+
+
+def test_load_rejects_unknown_version(tmp_path) -> None:
+    path = tmp_path / "future.pt"
+    snap = ActivationSnapshot(**_make_valid_fields())
+    blob = {
+        "_version": SNAPSHOT_SCHEMA_VERSION + 99,
+        "input_ids": snap.input_ids,
+        "attention_mask": snap.attention_mask,
+        "sample_ids": snap.sample_ids,
+        "activations": snap.activations,
+        "reduction": snap.reduction,
+    }
+    torch.save(blob, str(path))
+    with pytest.raises(ValueError, match=r"unknown ActivationSnapshot schema _version"):
+        ActivationSnapshot.load(path)
+
+
+def test_load_rejects_missing_keys(tmp_path) -> None:
+    path = tmp_path / "malformed.pt"
+    torch.save({"_version": SNAPSHOT_SCHEMA_VERSION, "input_ids": torch.zeros(2, 4)}, str(path))
+    with pytest.raises(ValueError, match=r"missing keys"):
+        ActivationSnapshot.load(path)
+
+
+def test_load_rejects_non_dict(tmp_path) -> None:
+    path = tmp_path / "weird.pt"
+    torch.save(torch.zeros(3), str(path))
+    with pytest.raises(ValueError, match=r"expected a dict"):
+        ActivationSnapshot.load(path)
+
+
+def test_load_validates_on_read(tmp_path) -> None:
+    """A dict with valid schema but broken invariants should raise __post_init__."""
+    path = tmp_path / "broken.pt"
+    blob = {
+        "_version": SNAPSHOT_SCHEMA_VERSION,
+        "input_ids": torch.zeros(4, 8, dtype=torch.long),
+        "attention_mask": torch.ones(4, 8, dtype=torch.long),
+        "sample_ids": [0, 1, 1, 2],  # duplicate — __post_init__ should reject
+        "activations": {"encoder.layer.0": torch.zeros(4, 16)},
+        "reduction": "mean",
+    }
+    torch.save(blob, str(path))
+    with pytest.raises(ValueError, match=r"unique"):
+        ActivationSnapshot.load(path)
+
+
+# ---- from_model --------------------------------------------------------------
+
+import torch.nn as nn  # noqa: E402
+
+
+class _TinyBertLike(nn.Module):
+    """Minimal transformer-shaped module for from_model tests.
+
+    Forward returns (B, L, H) after a stack of Linear layers on top of an
+    embedding. Deterministic under torch.manual_seed.
+    """
+
+    def __init__(self, vocab: int = 100, hidden: int = 8, n_layers: int = 2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [nn.Linear(hidden, hidden, bias=False) for _ in range(n_layers)]
+        )
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor | None = None):
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def _make_tiny_inputs(n: int = 4, seq_len: int = 6, vocab: int = 100, seed: int = 0):
+    torch.manual_seed(seed)
+    input_ids = torch.randint(0, vocab, (n, seq_len), dtype=torch.long)
+    attention_mask = torch.ones(n, seq_len, dtype=torch.long)
+    sample_ids = list(range(100, 100 + n))
+    return input_ids, attention_mask, sample_ids
+
+
+def test_from_model_matches_manual_extractor() -> None:
+    """from_model must produce identical activations to a direct ActivationExtractor pass."""
+    from manylatents.lightning.hooks import ActivationExtractor, LayerSpec
+
+    torch.manual_seed(42)
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+
+    layer_paths = ["layers.0", "layers.1"]
+    reduction = "mean"
+
+    snap = ActivationSnapshot.from_model(
+        model,
+        input_ids,
+        attention_mask,
+        sample_ids,
+        layer_paths,
+        reduction=reduction,
+        batch_size=2,
+    )
+
+    model.eval()
+    extractor = ActivationExtractor(
+        [LayerSpec(path=p, reduce=reduction) for p in layer_paths]
+    )
+    with torch.no_grad():
+        with extractor.capture(model):
+            model(input_ids=input_ids, attention_mask=attention_mask)
+    manual = extractor.get_activations()
+
+    assert set(snap.activations.keys()) == set(manual.keys())
+    for k in manual:
+        assert torch.allclose(snap.activations[k], manual[k], atol=1e-6), (
+            f"mismatch at layer {k}"
+        )
+
+
+def test_from_model_multiple_layers_captured() -> None:
+    model = _TinyBertLike(n_layers=3)
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+    snap = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.0", "layers.1", "layers.2"],
+        reduction="mean",
+    )
+    assert set(snap.activations.keys()) == {"layers.0", "layers.1", "layers.2"}
+    for tensor in snap.activations.values():
+        assert tensor.shape == (4, 8)
+
+
+def test_from_model_batching_equivalent_to_single_pass() -> None:
+    """Different batch sizes produce the same result."""
+    torch.manual_seed(7)
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs(n=10)
+
+    snap_batched = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids, ["layers.1"],
+        reduction="mean", batch_size=3,
+    )
+    snap_single = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids, ["layers.1"],
+        reduction="mean", batch_size=10,
+    )
+    assert torch.allclose(
+        snap_batched.activations["layers.1"],
+        snap_single.activations["layers.1"],
+        atol=1e-6,
+    )
+
+
+def test_from_model_pool_cls_returns_index_zero() -> None:
+    torch.manual_seed(0)
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+
+    snap = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.1"], reduction="cls",
+    )
+    # Manually capture raw layer.1 outputs to compare against [:, 0, :].
+    raw_outputs = []
+    handle = model.layers[1].register_forward_hook(
+        lambda m, i, o: raw_outputs.append(o.detach())
+    )
+    try:
+        model.eval()
+        with torch.no_grad():
+            model(input_ids=input_ids, attention_mask=attention_mask)
+    finally:
+        handle.remove()
+    raw = torch.cat(raw_outputs, dim=0)
+    assert torch.allclose(snap.activations["layers.1"], raw[:, 0, :], atol=1e-6)
+
+
+def test_from_model_pool_mean_matches_extractor_semantics() -> None:
+    """from_model 'mean' matches ActivationExtractor's unmasked tensor.mean(dim=1).
+
+    Note: does NOT exclude padding tokens from the mean — this matches the
+    existing collaborator behavior and the old pipeline/ code. Consumers who
+    need masked pooling should snapshot with reduction='none' and post-process.
+    """
+    torch.manual_seed(0)
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+
+    snap = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.0"], reduction="mean",
+    )
+    raw_outputs = []
+    handle = model.layers[0].register_forward_hook(
+        lambda m, i, o: raw_outputs.append(o.detach())
+    )
+    try:
+        model.eval()
+        with torch.no_grad():
+            model(input_ids=input_ids, attention_mask=attention_mask)
+    finally:
+        handle.remove()
+    raw = torch.cat(raw_outputs, dim=0)
+    assert torch.allclose(snap.activations["layers.0"], raw.mean(dim=1), atol=1e-6)
+
+
+def test_from_model_rejects_unknown_reduction() -> None:
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+    with pytest.raises(ValueError, match=r"reduction must be one of"):
+        ActivationSnapshot.from_model(
+            model, input_ids, attention_mask, sample_ids,
+            ["layers.0"], reduction="gibberish",
+        )
+
+
+def test_from_model_restores_training_mode() -> None:
+    model = _TinyBertLike()
+    model.train()
+    assert model.training
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+
+    ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.0"], reduction="mean",
+    )
+    assert model.training, "model.training must be restored after from_model"
+
+
+def test_from_model_no_hooks_leak_after_return() -> None:
+    """ActivationExtractor.capture context manager must tear down all hooks."""
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs()
+
+    ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.0", "layers.1"], reduction="mean",
+    )
+    for mod in model.modules():
+        assert len(mod._forward_hooks) == 0, (
+            f"lingering hook on {type(mod).__name__}"
+        )
+
+
+def test_from_model_result_passes_post_init() -> None:
+    """Snapshot from from_model must be a fully valid snapshot instance."""
+    model = _TinyBertLike()
+    input_ids, attention_mask, sample_ids = _make_tiny_inputs(n=5)
+    snap = ActivationSnapshot.from_model(
+        model, input_ids, attention_mask, sample_ids,
+        ["layers.0"], reduction="mean",
+    )
+    assert len(snap) == 5
+    assert snap.reduction == "mean"
+    # Reconstruct via save/load to exercise __post_init__ on a roundtrip.
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        path = f"{tmp}/snap.pt"
+        snap.save(path)
+        ActivationSnapshot.load(path)  # would raise if invariants broken
+
+
+def test_from_model_rejects_sample_ids_length_mismatch() -> None:
+    model = _TinyBertLike()
+    input_ids, attention_mask, _ = _make_tiny_inputs(n=4)
+    with pytest.raises(ValueError, match=r"len\(sample_ids\)"):
+        ActivationSnapshot.from_model(
+            model, input_ids, attention_mask, [0, 1, 2],  # wrong length
+            ["layers.0"], reduction="mean",
+        )

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -1,0 +1,516 @@
+"""Unit tests for Distillation LightningModule (task-only path)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from manylatents.algorithms.lightning.distillation import Distillation
+from manylatents.lightning.activation_snapshot import ActivationSnapshot
+
+
+# ---- Test fixtures -----------------------------------------------------------
+
+
+class _TinyLMStudent(nn.Module):
+    """HF-shaped tiny student: returns an object with .loss.
+
+    Used to avoid HF downloads in unit tests. Shape mirrors an MLM model:
+    ``forward(input_ids, attention_mask, labels=None) -> (loss, logits)``.
+    """
+
+    def __init__(self, vocab: int = 100, hidden: int = 8, n_layers: int = 2) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [nn.Linear(hidden, hidden, bias=True) for _ in range(n_layers)]
+        )
+        # Include a LayerNorm so weight-decay partitioning has something to find.
+        self.final_ln = nn.LayerNorm(hidden)
+        self.head = nn.Linear(hidden, vocab, bias=True)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+    ):
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.final_ln(x)
+        logits = self.head(x)
+
+        loss = None
+        if labels is not None:
+            loss = F.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                labels.view(-1),
+                ignore_index=-100,
+            )
+        return SimpleNamespace(loss=loss, logits=logits)
+
+
+def _make_snapshot(n: int = 4, hidden: int = 8) -> ActivationSnapshot:
+    torch.manual_seed(0)
+    return ActivationSnapshot(
+        input_ids=torch.randint(0, 100, (n, 6), dtype=torch.long),
+        attention_mask=torch.ones(n, 6, dtype=torch.long),
+        sample_ids=list(range(n)),
+        activations={"layers.1": torch.randn(n, hidden)},
+        reduction="mean",
+    )
+
+
+def _make_task_batch(batch_size: int = 4, seq_len: int = 6, vocab: int = 100):
+    input_ids = torch.randint(0, vocab, (batch_size, seq_len), dtype=torch.long)
+    return {
+        "input_ids": input_ids,
+        "attention_mask": torch.ones_like(input_ids),
+        "labels": input_ids.clone(),
+    }
+
+
+# ---- Tests -------------------------------------------------------------------
+
+
+def test_construct_with_zero_alignment_weight() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],  # empty is fine when alignment_weight=0
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    assert mod.alignment_weight == 0.0
+    assert mod.student is student
+    assert mod.snapshot is snap
+
+
+def test_training_step_task_only_finite() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    batch = _make_task_batch()
+    loss = mod.training_step(batch, batch_idx=0)
+    assert torch.isfinite(loss).item()
+    assert loss.requires_grad
+
+
+def test_training_step_returns_task_loss_when_alignment_zero() -> None:
+    """When alignment_weight=0, training_step must equal the task loss exactly
+    (no alignment term added)."""
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    batch = _make_task_batch()
+    total = mod.training_step(batch, batch_idx=0)
+    with torch.no_grad():
+        raw_task = mod(**batch).loss
+    assert torch.allclose(total.detach(), raw_task)
+
+
+def test_configure_optimizers_two_param_groups_bias_ln_no_decay() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3, "weight_decay": 0.01},
+        alignment_weight=0.0,
+    )
+    optimizer = mod.configure_optimizers()
+    assert isinstance(optimizer, torch.optim.AdamW)
+    assert len(optimizer.param_groups) == 2
+    decay_group, no_decay_group = optimizer.param_groups
+    assert decay_group["weight_decay"] == 0.01
+    assert no_decay_group["weight_decay"] == 0.0
+
+    # Build a name lookup from parameter object identity so we can check which
+    # params ended up where.
+    id_to_name = {id(p): n for n, p in student.named_parameters()}
+    no_decay_names = [id_to_name[id(p)] for p in no_decay_group["params"]]
+    decay_names = [id_to_name[id(p)] for p in decay_group["params"]]
+
+    # Every bias and LayerNorm weight should be in no_decay.
+    for name in decay_names:
+        assert not name.endswith(".bias"), f"{name} should be in no_decay"
+    assert any(n.endswith(".bias") for n in no_decay_names)
+    # The final_ln (nn.LayerNorm) parameters must be in no_decay.
+    norm_param_ids = {
+        id(p) for p in student.final_ln.parameters()
+    }
+    no_decay_param_ids = {id(p) for p in no_decay_group["params"]}
+    assert norm_param_ids.issubset(no_decay_param_ids), (
+        "LayerNorm params must be in no_decay group"
+    )
+
+
+def test_configure_optimizers_filters_requires_grad_false() -> None:
+    """Frozen params must not appear in optimizer — this is what makes
+    StagedTrainingCallback's freeze semantic actually freeze."""
+    student = _TinyLMStudent()
+    # Freeze layer 0
+    for p in student.layers[0].parameters():
+        p.requires_grad = False
+
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    optimizer = mod.configure_optimizers()
+    all_opt_params = [p for g in optimizer.param_groups for p in g["params"]]
+    frozen_ids = {id(p) for p in student.layers[0].parameters()}
+    for p in all_opt_params:
+        assert id(p) not in frozen_ids, "frozen param leaked into optimizer"
+
+
+def test_layer_pairs_empty_with_nonzero_alignment_raises() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    with pytest.raises(ValueError, match=r"layer_pairs must be non-empty"):
+        Distillation(
+            datamodule=None,
+            student=student,
+            activation_snapshot=snap,
+            layer_pairs=[],
+            optimizer={"learning_rate": 1e-3},
+            alignment_weight=1.0,
+        )
+
+
+def test_layer_pairs_teacher_missing_from_snapshot_raises() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()  # keys: {"layers.1"}
+    with pytest.raises(ValueError, match=r"not in snapshot\.activations"):
+        Distillation(
+            datamodule=None,
+            student=student,
+            activation_snapshot=snap,
+            layer_pairs=[{"student": "layers.0", "teacher": "layers.99", "weight": 1.0}],
+            optimizer={"learning_rate": 1e-3},
+            alignment_weight=1.0,
+        )
+
+
+def test_layer_pairs_invalid_student_path_raises() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    with pytest.raises(ValueError, match=r"does not\s+resolve"):
+        Distillation(
+            datamodule=None,
+            student=student,
+            activation_snapshot=snap,
+            layer_pairs=[
+                {"student": "nonexistent.path", "teacher": "layers.1", "weight": 1.0}
+            ],
+            optimizer={"learning_rate": 1e-3},
+            alignment_weight=1.0,
+        )
+
+
+def test_snapshot_tensors_registered_as_buffers() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    # input_ids + attention_mask + one-per-layer activation target.
+    buffer_names = dict(mod.named_buffers())
+    assert "_probe_input_ids" in buffer_names
+    assert "_probe_attention_mask" in buffer_names
+    # Layer "layers.1" → sanitized buffer name.
+    assert any("target" in n and "layers_1" in n for n in buffer_names)
+
+
+def test_snapshot_buffers_move_with_to() -> None:
+    """.to('meta') should move snapshot tensors just like any other buffer."""
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    mod_meta = mod.to("meta")
+    assert mod_meta._probe_input_ids.device.type == "meta"
+    assert mod_meta._probe_attention_mask.device.type == "meta"
+
+
+def test_snapshot_property_returns_input() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+    )
+    assert mod.snapshot is snap
+    # Reduction must be readable from the snapshot, not duplicated on the module.
+    assert mod.snapshot.reduction == "mean"
+
+
+# ---- Alignment path (step 7) -------------------------------------------------
+
+
+def _make_snapshot_for_layers(
+    student: _TinyLMStudent, layer_paths: list, n: int = 4
+) -> ActivationSnapshot:
+    """Build a snapshot from the student itself at the requested layers.
+
+    Using the student as its own 'teacher' gives us a snapshot whose targets
+    exactly equal what the student would produce at init, which lets us
+    assert the alignment loss is near-zero on the first step.
+    """
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, 100, (n, 6), dtype=torch.long)
+    attention_mask = torch.ones(n, 6, dtype=torch.long)
+    return ActivationSnapshot.from_model(
+        student,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        sample_ids=list(range(n)),
+        layer_paths=layer_paths,
+        reduction="mean",
+        batch_size=4,
+    )
+
+
+def test_training_step_with_alignment_adds_term() -> None:
+    """Total loss with alignment_weight=1.0 must strictly exceed the task loss
+    alone (the alignment MSE is > 0 for a freshly-initialized student against
+    a target built from a DIFFERENT model seed)."""
+    torch.manual_seed(42)
+    student_a = _TinyLMStudent()
+    # Build snapshot from a DIFFERENT model so align MSE is nonzero.
+    teacher = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(teacher, ["layers.1"])
+
+    mod = Distillation(
+        datamodule=None,
+        student=student_a,
+        activation_snapshot=snap,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=1.0,
+        alignment_batch_size=4,
+    )
+    batch = _make_task_batch()
+
+    torch.manual_seed(0)
+    total = mod.training_step(batch, batch_idx=0)
+
+    with torch.no_grad():
+        raw_task = mod(**batch).loss
+    assert total.detach() > raw_task.detach(), (
+        f"total ({total.item()}) should exceed task ({raw_task.item()}) "
+        f"when alignment MSE > 0"
+    )
+
+
+def test_alignment_loss_zero_when_student_matches_teacher() -> None:
+    """Snapshot built FROM the student at initialization → alignment MSE ≈ 0
+    on first call. Validates the reduction+layer-lookup plumbing end-to-end.
+    """
+    torch.manual_seed(99)
+    student = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(student, ["layers.1"])
+
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=1.0,
+        alignment_batch_size=4,
+    )
+    align = mod._alignment_loss()
+    assert align.item() < 1e-6, f"expected ≈0, got {align.item()}"
+
+
+def test_alignment_loss_no_lingering_hooks() -> None:
+    """After _alignment_loss returns, no forward hooks should remain on any
+    submodule of the student. This is the critical guard against the prior
+    refactor's memory-bloat / gradient-corruption failure mode.
+    """
+    student = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(student, ["layers.1"])
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=1.0,
+        alignment_batch_size=4,
+    )
+    mod._alignment_loss()
+    for m in student.modules():
+        assert len(m._forward_hooks) == 0, (
+            f"lingering hook on {type(m).__name__}"
+        )
+
+
+def test_alignment_loss_does_not_leak_memory_across_steps() -> None:
+    """50 consecutive _alignment_loss calls should not monotonically grow
+    the number of registered hooks. (A full memory-RSS test is noisy on CI;
+    hook-count is the clean proxy for the actual concern.)
+    """
+    student = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(student, ["layers.1"])
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=1.0,
+        alignment_batch_size=4,
+    )
+    for _ in range(50):
+        mod._alignment_loss()
+    total_hooks = sum(len(m._forward_hooks) for m in student.modules())
+    assert total_hooks == 0, f"hooks accumulated: total={total_hooks}"
+
+
+def test_alignment_loss_respects_pair_weights() -> None:
+    """Doubling a layer pair's weight should double the contribution of that
+    layer's MSE to the total alignment loss."""
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(teacher, ["layers.0", "layers.1"])
+
+    def build(w0: float, w1: float) -> Distillation:
+        return Distillation(
+            datamodule=None,
+            student=student,
+            activation_snapshot=snap,
+            layer_pairs=[
+                {"student": "layers.0", "teacher": "layers.0", "weight": w0},
+                {"student": "layers.1", "teacher": "layers.1", "weight": w1},
+            ],
+            optimizer={"learning_rate": 1e-3},
+            alignment_weight=1.0,
+            alignment_batch_size=4,
+        )
+
+    torch.manual_seed(0)
+    loss_equal = build(1.0, 1.0)._alignment_loss().item()
+    torch.manual_seed(0)
+    loss_doubled = build(2.0, 2.0)._alignment_loss().item()
+    assert loss_doubled == pytest.approx(2 * loss_equal, rel=1e-5)
+
+
+def test_alignment_loss_reads_reduction_from_snapshot() -> None:
+    """Changing snapshot.reduction must change which pooling the student
+    forward uses - verify by comparing cls vs mean snapshots."""
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()
+
+    torch.manual_seed(0)
+    ids = torch.randint(0, 100, (4, 6), dtype=torch.long)
+    mask = torch.ones_like(ids)
+    snap_mean = ActivationSnapshot.from_model(
+        teacher, ids, mask, [0, 1, 2, 3], ["layers.1"], reduction="mean"
+    )
+    snap_cls = ActivationSnapshot.from_model(
+        teacher, ids, mask, [0, 1, 2, 3], ["layers.1"], reduction="cls"
+    )
+
+    def loss_for(snap):
+        mod = Distillation(
+            datamodule=None,
+            student=student,
+            activation_snapshot=snap,
+            layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+            optimizer={"learning_rate": 1e-3},
+            alignment_weight=1.0,
+            alignment_batch_size=4,
+        )
+        torch.manual_seed(0)
+        return mod._alignment_loss().item()
+
+    assert loss_for(snap_mean) != pytest.approx(loss_for(snap_cls), rel=1e-3), (
+        "mean and cls reductions must produce different alignment losses"
+    )
+
+
+def test_training_step_alignment_path_differentiable() -> None:
+    """The full training_step with alignment must produce a loss that
+    backprops cleanly (no detach, no broken graph)."""
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()
+    snap = _make_snapshot_for_layers(teacher, ["layers.1"])
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 0.5}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=1.0,
+        alignment_batch_size=4,
+    )
+    batch = _make_task_batch()
+    loss = mod.training_step(batch, batch_idx=0)
+    loss.backward()
+    # Verify at least one student param received a gradient.
+    assert any(p.grad is not None and torch.any(p.grad != 0) for p in student.parameters())
+
+
+def test_setup_seeds_deterministically() -> None:
+    student = _TinyLMStudent()
+    snap = _make_snapshot()
+    mod = Distillation(
+        datamodule=None,
+        student=student,
+        activation_snapshot=snap,
+        layer_pairs=[],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=0.0,
+        init_seed=1234,
+    )
+    mod.setup()
+    a = torch.randn(3)
+    mod.setup()
+    b = torch.randn(3)
+    assert torch.equal(a, b), "setup must reseed so torch.randn is deterministic"

--- a/tests/test_distillation_configs.py
+++ b/tests/test_distillation_configs.py
@@ -1,0 +1,63 @@
+"""Hydra config smoke tests for distillation/*.yaml.
+
+Verifies that every distillation YAML composes cleanly and carries the
+expected ``_target_`` pointers. Does NOT instantiate - instantiation would
+require a concrete student and snapshot path at compose time, and the
+configs declare those as ``???`` (required overrides).
+"""
+from __future__ import annotations
+
+import pytest
+from hydra import compose, initialize_config_module
+from omegaconf import OmegaConf
+
+
+def _compose(name: str):
+    # config_module points at manylatents.configs; we use the algorithms/lightning
+    # subgroup to pick our distillation variant.
+    with initialize_config_module(
+        config_module="manylatents.configs", version_base=None
+    ):
+        return compose(
+            config_name="config",
+            overrides=[
+                f"algorithms/lightning=distillation/{name}",
+                "data=swissroll",
+            ],
+        )
+
+
+@pytest.mark.parametrize("name", ["base", "staged", "control_task_only"])
+def test_config_composes(name: str) -> None:
+    cfg = _compose(name)
+    algo = cfg.algorithms.lightning
+    assert algo._target_ == (
+        "manylatents.algorithms.lightning.distillation.Distillation"
+    )
+    # activation_snapshot uses the load classmethod
+    assert algo.activation_snapshot._target_.endswith("ActivationSnapshot.load")
+
+
+def test_base_has_zero_alignment_weight() -> None:
+    cfg = _compose("base")
+    assert cfg.algorithms.lightning.alignment_weight == 0.0
+
+
+def test_staged_has_unit_alignment_weight() -> None:
+    cfg = _compose("staged")
+    assert cfg.algorithms.lightning.alignment_weight == 1.0
+
+
+def test_control_task_only_has_zero_alignment_weight() -> None:
+    cfg = _compose("control_task_only")
+    assert cfg.algorithms.lightning.alignment_weight == 0.0
+
+
+def test_staged_inherits_from_base() -> None:
+    """Staged config uses `defaults: [base]` — verify inherited fields are present."""
+    cfg = _compose("staged")
+    algo = cfg.algorithms.lightning
+    # Fields present only because they're inherited from base:
+    assert "optimizer" in algo
+    assert "init_seed" in algo
+    assert algo.optimizer.learning_rate == 2e-5

--- a/tests/test_distillation_end_to_end.py
+++ b/tests/test_distillation_end_to_end.py
@@ -1,0 +1,315 @@
+"""End-to-end integration test for the distillation algo module.
+
+Composes the full pipeline:
+  ActivationSnapshot.from_model  (teacher, probe set)
+  align_on_snapshot              (phase1, imperative)
+  trainer.fit(Distillation, ...) (phase2 → phase3 via StagedTrainingCallback)
+
+Runs entirely on CPU in <60s with tiny synthetic models + synthetic data.
+Protects the integration surface area between the four pieces built on
+``distillation-algo-module``.
+
+Primary contracts protected:
+- snapshot.sample_ids IS the id space the datamodule uses (the failure mode
+  the prior refactor died on: mismatched id spaces between teacher probe
+  extraction and training-time probe lookup)
+- phase1 seed flows end-to-end so a same-seed rerun produces identical losses
+- StagedTrainingCallback correctly freezes aligned-layer params during phase2
+  and unfreezes at phase3_start_step
+- 15 total optimizer steps (5 phase1 + 10 phase2+3) all yield finite losses
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from lightning.pytorch import LightningDataModule, Trainer
+from torch.utils.data import DataLoader, TensorDataset
+
+from manylatents.algorithms.lightning.distillation import Distillation
+from manylatents.algorithms.lightning.phase1_align import align_on_snapshot
+from manylatents.lightning.callbacks.staged_training import StagedTrainingCallback
+from manylatents.lightning.activation_snapshot import ActivationSnapshot
+
+
+# ---- Minimal fixtures --------------------------------------------------------
+
+
+class _TinyLMStudent(nn.Module):
+    """Same minimal HF-shaped student used across the unit tests."""
+
+    def __init__(self, vocab: int = 64, hidden: int = 8, n_layers: int = 2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [nn.Linear(hidden, hidden, bias=True) for _ in range(n_layers)]
+        )
+        self.final_ln = nn.LayerNorm(hidden)
+        self.head = nn.Linear(hidden, vocab, bias=True)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+    ):
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.final_ln(x)
+        logits = self.head(x)
+        loss = None
+        if labels is not None:
+            loss = F.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                labels.view(-1),
+                ignore_index=-100,
+            )
+        return SimpleNamespace(loss=loss, logits=logits)
+
+
+class _SyntheticTaskDataModule(LightningDataModule):
+    """In-memory task datamodule + exposed probe IDs.
+
+    Holds a small fixed training set of (input_ids, attention_mask, labels).
+    Exposes a ``probe_ids`` list so consumers can build a snapshot keyed to
+    the same ID space the datamodule emits at training time - this is the
+    contract the end-to-end test locks.
+    """
+
+    def __init__(
+        self,
+        n_train: int = 32,
+        n_probe: int = 8,
+        seq_len: int = 6,
+        vocab: int = 64,
+        batch_size: int = 4,
+        seed: int = 7,
+    ):
+        super().__init__()
+        self.batch_size = batch_size
+        self.seed = seed
+
+        torch.manual_seed(seed)
+        self._train_ids = torch.randint(0, vocab, (n_train, seq_len))
+        self._train_mask = torch.ones(n_train, seq_len, dtype=torch.long)
+        self._train_labels = self._train_ids.clone()
+
+        self._probe_ids = torch.randint(0, vocab, (n_probe, seq_len))
+        self._probe_mask = torch.ones(n_probe, seq_len, dtype=torch.long)
+        # Stable integer identifiers for each probe row. Any consumer that
+        # builds a snapshot against self._probe_ids must pass these same
+        # values as snapshot.sample_ids.
+        self.probe_ids: List[int] = list(range(1000, 1000 + n_probe))
+
+    def setup(self, stage=None):
+        pass
+
+    def train_dataloader(self):
+        ds = TensorDataset(self._train_ids, self._train_mask, self._train_labels)
+
+        def collate(batch):
+            ids = torch.stack([b[0] for b in batch])
+            mask = torch.stack([b[1] for b in batch])
+            labels = torch.stack([b[2] for b in batch])
+            return {"input_ids": ids, "attention_mask": mask, "labels": labels}
+
+        return DataLoader(ds, batch_size=self.batch_size, collate_fn=collate, shuffle=False)
+
+    @property
+    def probe_input_ids(self):
+        return self._probe_ids
+
+    @property
+    def probe_attention_mask(self):
+        return self._probe_mask
+
+
+def _build_pipeline(
+    student: nn.Module,
+    teacher: nn.Module,
+    dm: _SyntheticTaskDataModule,
+    alignment_weight: float = 1.0,
+    phase3_start_step: int = 5,
+    frozen_prefixes: Optional[List[str]] = None,
+):
+    """Build a (snapshot, distillation_module, phase1_losses) triple up to
+    just-before trainer.fit."""
+    # 1. Snapshot against the teacher on the datamodule's probe inputs, keyed
+    #    by the datamodule's probe_ids.
+    snapshot = ActivationSnapshot.from_model(
+        teacher,
+        input_ids=dm.probe_input_ids,
+        attention_mask=dm.probe_attention_mask,
+        sample_ids=dm.probe_ids,
+        layer_paths=["layers.1"],
+        reduction="mean",
+    )
+
+    # 2. Phase1 imperative alignment using the datamodule's seed.
+    phase1_losses = align_on_snapshot(
+        student,
+        snapshot,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        n_steps=5,
+        optimizer_cfg={"learning_rate": 1e-2},
+        batch_size=4,
+        seed=dm.seed,
+        device="cpu",
+    )
+
+    # 3. Distillation module for phase2/3.
+    mod = Distillation(
+        datamodule=dm,
+        student=student,
+        activation_snapshot=snapshot,
+        layer_pairs=[{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        optimizer={"learning_rate": 1e-3},
+        alignment_weight=alignment_weight,
+        alignment_batch_size=4,
+        init_seed=dm.seed,
+    )
+    return snapshot, mod, phase1_losses
+
+
+# ---- Tests -------------------------------------------------------------------
+
+
+def test_snapshot_sample_ids_match_text_datamodule_probe_ids() -> None:
+    """Sharpest residual risk called out in the reviewer log: snapshot must
+    be built against the same probe_ids the datamodule emits."""
+    torch.manual_seed(0)
+    teacher = _TinyLMStudent()
+    dm = _SyntheticTaskDataModule()
+
+    snap = ActivationSnapshot.from_model(
+        teacher,
+        input_ids=dm.probe_input_ids,
+        attention_mask=dm.probe_attention_mask,
+        sample_ids=dm.probe_ids,
+        layer_paths=["layers.1"],
+        reduction="mean",
+    )
+    assert set(snap.sample_ids) == set(dm.probe_ids)
+
+
+def test_end_to_end_phase1_then_fit_runs_cleanly() -> None:
+    """Full pipeline: snapshot → phase1 → fit. Counts optimizer steps and
+    asserts every loss is finite."""
+    torch.manual_seed(0)
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()  # different init
+    dm = _SyntheticTaskDataModule()
+
+    _, mod, phase1_losses = _build_pipeline(
+        student, teacher, dm,
+        alignment_weight=1.0,
+        phase3_start_step=5,
+    )
+
+    assert len(phase1_losses) == 5
+    assert all(torch.tensor(l).isfinite().item() for l in phase1_losses)
+
+    callback = StagedTrainingCallback(
+        phase3_start_step=5,
+        frozen_prefixes_phase2=["student.layers.1"],
+    )
+    trainer = Trainer(
+        max_steps=10,
+        accelerator="cpu",
+        callbacks=[callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
+    trainer.fit(mod, datamodule=dm)
+    assert trainer.global_step == 10
+
+
+def test_phase1_and_phase2_use_consistent_seed() -> None:
+    """Same seed end-to-end → identical phase1 loss trajectories on a
+    two-run comparison."""
+    def run_phase1():
+        torch.manual_seed(1234)
+        student = _TinyLMStudent()
+        teacher = _TinyLMStudent()
+        dm = _SyntheticTaskDataModule(seed=7)
+        _, _, p1 = _build_pipeline(student, teacher, dm)
+        return p1
+
+    a = run_phase1()
+    b = run_phase1()
+    assert a == b, f"non-deterministic under fixed seeds: a={a} b={b}"
+
+
+def test_staged_callback_freezes_aligned_layers_during_phase2() -> None:
+    """During steps 0..phase3_start_step-1, aligned-layer params must have
+    requires_grad=False. After the transition, requires_grad is True."""
+    torch.manual_seed(0)
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()
+    dm = _SyntheticTaskDataModule()
+    _, mod, _ = _build_pipeline(student, teacher, dm)
+
+    observed_requires_grad = []
+
+    class _Probe(StagedTrainingCallback):
+        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+            observed_requires_grad.append(
+                (trainer.global_step, pl_module.student.layers[1].weight.requires_grad)
+            )
+            super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
+
+    callback = _Probe(
+        phase3_start_step=5,
+        frozen_prefixes_phase2=["student.layers.1"],
+    )
+    trainer = Trainer(
+        max_steps=10,
+        accelerator="cpu",
+        callbacks=[callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
+    trainer.fit(mod, datamodule=dm)
+
+    # During phase2 (steps 1..5), observed value should be False.
+    # After phase3 transition (callback fires at end of step 5 → global_step 6
+    # onward sees it unfrozen).
+    phase2_obs = [(s, r) for s, r in observed_requires_grad if s < 5]
+    phase3_obs = [(s, r) for s, r in observed_requires_grad if s >= 6]
+    assert phase2_obs, "no phase2 observations"
+    assert phase3_obs, "no phase3 observations"
+    assert all(not r for _, r in phase2_obs), (
+        f"phase2 layers.1.weight should be frozen; got {phase2_obs}"
+    )
+    assert all(r for _, r in phase3_obs), (
+        f"phase3 layers.1.weight should be trainable; got {phase3_obs}"
+    )
+
+
+def test_control_task_only_all_losses_finite() -> None:
+    """alignment_weight=0 config: pure task training still runs end-to-end."""
+    torch.manual_seed(0)
+    student = _TinyLMStudent()
+    teacher = _TinyLMStudent()
+    dm = _SyntheticTaskDataModule()
+    _, mod, _ = _build_pipeline(student, teacher, dm, alignment_weight=0.0)
+
+    trainer = Trainer(
+        max_steps=10,
+        accelerator="cpu",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
+    trainer.fit(mod, datamodule=dm)
+    assert trainer.global_step == 10

--- a/tests/test_phase1_align.py
+++ b/tests/test_phase1_align.py
@@ -1,0 +1,235 @@
+"""Unit tests for align_on_snapshot phase1 helper."""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from manylatents.algorithms.lightning.phase1_align import align_on_snapshot
+from manylatents.lightning.activation_snapshot import ActivationSnapshot
+
+
+class _TinyStudent(nn.Module):
+    """Minimal transformer-shaped student for phase1 tests. Same shape as
+    the _TinyBertLike in test_activation_snapshot but without a vocab head
+    (phase1 only needs hidden activations, not token logits)."""
+
+    def __init__(self, vocab: int = 100, hidden: int = 8, n_layers: int = 2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [nn.Linear(hidden, hidden, bias=False) for _ in range(n_layers)]
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ):
+        x = self.embed(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def _build_snapshot(n: int = 16, hidden: int = 8, seed: int = 0) -> ActivationSnapshot:
+    torch.manual_seed(seed)
+    # Build a snapshot from a DIFFERENT random init so MSE is non-trivial.
+    teacher = _TinyStudent(hidden=hidden)
+    input_ids = torch.randint(0, 100, (n, 6), dtype=torch.long)
+    attention_mask = torch.ones(n, 6, dtype=torch.long)
+    return ActivationSnapshot.from_model(
+        teacher,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        sample_ids=list(range(n)),
+        layer_paths=["layers.1"],
+        reduction="mean",
+    )
+
+
+def _default_pairs():
+    return [{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}]
+
+
+def test_align_reduces_mse_monotone_window() -> None:
+    """20 steps on a tiny fixture: mean of last 5 losses < mean of first 5."""
+    torch.manual_seed(42)
+    student = _TinyStudent()
+    snap = _build_snapshot(seed=7)
+
+    losses = align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=20,
+        optimizer_cfg={"learning_rate": 1e-2},
+        batch_size=8, seed=123, device="cpu",
+    )
+
+    assert len(losses) == 20
+    early = sum(losses[:5]) / 5
+    late = sum(losses[-5:]) / 5
+    assert late < early, f"expected decrease; early={early:.4f} late={late:.4f}"
+
+
+def test_align_deterministic_under_seed() -> None:
+    """Same seed, same student init, same snapshot → identical trajectories."""
+    def run():
+        torch.manual_seed(999)
+        student = _TinyStudent()
+        snap = _build_snapshot(seed=7)
+        return align_on_snapshot(
+            student, snap, _default_pairs(),
+            n_steps=5,
+            optimizer_cfg={"learning_rate": 1e-2},
+            batch_size=4, seed=42, device="cpu",
+        )
+
+    a = run()
+    b = run()
+    assert a == b, f"non-deterministic: a={a} b={b}"
+
+
+def test_align_n_steps_zero_returns_empty() -> None:
+    student = _TinyStudent()
+    snap = _build_snapshot()
+    losses = align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=0,
+        optimizer_cfg={"learning_rate": 1e-3},
+        device="cpu",
+    )
+    assert losses == []
+
+
+def test_align_restores_student_hooks_removed() -> None:
+    """After return, no forward hooks should remain on any submodule."""
+    student = _TinyStudent()
+    snap = _build_snapshot()
+    align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=3,
+        optimizer_cfg={"learning_rate": 1e-3},
+        device="cpu",
+    )
+    for m in student.modules():
+        assert len(m._forward_hooks) == 0, (
+            f"lingering hook on {type(m).__name__}"
+        )
+
+
+def test_align_respects_layer_pair_weights() -> None:
+    """Doubling pair weights doubles the loss values."""
+    torch.manual_seed(0)
+    student_a = _TinyStudent()
+    torch.manual_seed(0)
+    student_b = _TinyStudent()
+    snap = _build_snapshot(seed=7)
+
+    losses_w1 = align_on_snapshot(
+        student_a, snap,
+        [{"student": "layers.1", "teacher": "layers.1", "weight": 1.0}],
+        n_steps=1,
+        optimizer_cfg={"learning_rate": 1e-10},  # tiny LR -> weights ~ unchanged
+        batch_size=8, seed=42, device="cpu",
+    )
+    losses_w2 = align_on_snapshot(
+        student_b, snap,
+        [{"student": "layers.1", "teacher": "layers.1", "weight": 2.0}],
+        n_steps=1,
+        optimizer_cfg={"learning_rate": 1e-10},
+        batch_size=8, seed=42, device="cpu",
+    )
+    assert losses_w2[0] == pytest.approx(2 * losses_w1[0], rel=1e-3)
+
+
+def test_align_raises_on_device_mismatch() -> None:
+    """Snapshot on one device, align_on_snapshot asked for another → raise."""
+    student = _TinyStudent()
+    snap = _build_snapshot()  # on CPU
+    with pytest.raises(ValueError, match=r"device=meta.*other devices"):
+        align_on_snapshot(
+            student, snap, _default_pairs(),
+            n_steps=1,
+            optimizer_cfg={"learning_rate": 1e-3},
+            device="meta",
+        )
+
+
+def test_align_raises_on_unresolvable_student_path() -> None:
+    student = _TinyStudent()
+    snap = _build_snapshot()
+    with pytest.raises(ValueError, match=r"does not resolve"):
+        align_on_snapshot(
+            student, snap,
+            [{"student": "nonexistent.path", "teacher": "layers.1", "weight": 1.0}],
+            n_steps=1,
+            optimizer_cfg={"learning_rate": 1e-3},
+            device="cpu",
+        )
+
+
+def test_align_uses_fresh_optimizer() -> None:
+    """Pre-existing optimizer attr on the student must not be touched."""
+    student = _TinyStudent()
+    pre_existing_marker = torch.optim.SGD(student.parameters(), lr=0.0)
+    student.optimizer = pre_existing_marker  # type: ignore[attr-defined]
+    snap = _build_snapshot()
+
+    align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=2,
+        optimizer_cfg={"learning_rate": 1e-3},
+        device="cpu",
+    )
+    assert student.optimizer is pre_existing_marker  # type: ignore[attr-defined]
+
+
+def test_align_updates_only_requires_grad_true() -> None:
+    """Frozen params should not receive gradient updates during phase1."""
+    student = _TinyStudent()
+    for p in student.embed.parameters():
+        p.requires_grad = False
+    embed_before = student.embed.weight.detach().clone()
+
+    snap = _build_snapshot()
+    align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=5,
+        optimizer_cfg={"learning_rate": 1e-1},
+        device="cpu",
+    )
+    assert torch.equal(student.embed.weight.detach(), embed_before), (
+        "frozen embed must not change during phase1"
+    )
+
+
+def test_align_losses_are_finite() -> None:
+    student = _TinyStudent()
+    snap = _build_snapshot()
+    losses = align_on_snapshot(
+        student, snap, _default_pairs(),
+        n_steps=10,
+        optimizer_cfg={"learning_rate": 1e-3},
+        batch_size=8, seed=1, device="cpu",
+    )
+    assert all(float(l) == float(l) for l in losses), "NaN loss"  # NaN check
+    assert all(abs(l) < 1e6 for l in losses), f"diverged: {losses}"
+
+
+def test_align_seed_variation_produces_different_losses() -> None:
+    """Different seeds should produce different per-step losses (else the
+    sampler is deterministic in the wrong dimension)."""
+    def run(seed):
+        torch.manual_seed(0)
+        student = _TinyStudent()
+        snap = _build_snapshot(seed=7)
+        return align_on_snapshot(
+            student, snap, _default_pairs(),
+            n_steps=3,
+            optimizer_cfg={"learning_rate": 1e-6},  # so loss ≈ initial MSE shape
+            batch_size=4, seed=seed, device="cpu",
+        )
+
+    a = run(11)
+    b = run(12)
+    assert a != b, f"different seeds produced identical losses: {a}"


### PR DESCRIPTION
## Summary

New core surface for within-family PHATE-target distillation, built natively on existing Lightning + hooks infra — no `pipeline/` layer, no orchestration leaking into the library.

- **`manylatents.lightning.activation_snapshot.ActivationSnapshot`** — frozen dataclass + `from_model(...)` producer + versioned `save`/`load`
- **`manylatents.algorithms.lightning.distillation.Distillation`** — LightningModule with optional alignment regularizer
- **`manylatents.algorithms.lightning.phase1_align.align_on_snapshot(...)`** — imperative alignment pre-pass over any `nn.Module` (not wrapped in `trainer.fit`)
- **`manylatents.lightning.callbacks.staged_training.StagedTrainingCallback`** — phase2 → phase3 freeze/unfreeze boundary
- Three Hydra variants under `configs/algorithms/lightning/distillation/`: `base`, `staged`, `control_task_only`

## Architectural commitments (non-obvious)

- **Phase1 outside `trainer.fit`.** Phase1 is a closed-form pass over a fixed probe buffer with pre-computed targets; Lightning's dataloader-per-step model doesn't fit. Every prior attempt to wedge phase1 into a LightningModule produced structural friction. `align_on_snapshot` is a free function over any `nn.Module`, making it reusable for probing warmups, CKA warmups, etc.
- **Phase2+Phase3 inside one `trainer.fit`.** `StagedTrainingCallback` flips `requires_grad` on the freeze boundary and rebuilds the optimizer. Adam state is preserved across rebuild for params that were trainable through phase2 (`id(p)` keying).
- **One reduction per snapshot.** If you want `mean` at layer 11 and `cls` at layer 3, you materialize two snapshots. The reduction string lives on the snapshot; consumers read it directly rather than restating it.
- **Weight-decay split by module type, not name.** `AdamW` groups split `weight_decayed` / `bias+norm` via `isinstance(nn.LayerNorm) or type(m).__name__.endswith("Norm")` — catches `final_ln` / `attn_norm` / `RMSNorm` cases that a substring match on param names misses.
- **Freeze semantic relies on `requires_grad`.** `Distillation.configure_optimizers` filters by `requires_grad`, so a param frozen by the callback is simply absent from the optimizer. That's what makes the freeze actually freeze.

## `hooks.py` change

`ActivationExtractor.__init__` gains an opt-in `detach: bool = True` kwarg. `Distillation._alignment_loss` and `align_on_snapshot` both need grad-carrying activations to backprop through the student. Default preserves the existing always-detach behavior; the existing 13 `ActivationExtractor` tests pass untouched.

## Three-line consumer idea

```python
snap = ActivationSnapshot.from_model(teacher, input_ids, attention_mask, sample_ids=probe_ids,
                                     layer_paths=["bert.encoder.layer.22"], reduction="mean")
phase1_losses = align_on_snapshot(student, snap, layer_pairs=[...], n_steps=1000,
                                  optimizer_cfg={"learning_rate": 3e-4}, device="cuda")
trainer = Trainer(max_steps=10_000, callbacks=[StagedTrainingCallback(
    phase3_start_step=5000, frozen_prefixes_phase2=["student.bert.encoder.layer.10"])])
trainer.fit(Distillation(datamodule=dm, student=student, activation_snapshot=snap, ...), datamodule=dm)
```

## Test plan

- [x] 28 `ActivationSnapshot` tests (invariants, save/load roundtrip, version gate, `from_model` extractor equivalence, cls/mean semantic, no hook leak, training-mode restore)
- [x] 19 `Distillation` tests (task loss, alignment regularizer, hook teardown per call, 50-call non-accumulation, pair-weight scaling, grad flow, reduction read from snapshot)
- [x] 11 `align_on_snapshot` tests (monotone descent window, determinism under seed, device-match with cuda/cuda:0 semantic, frozen params untouched)
- [x] 22 `StagedTrainingCallback` tests (dot-boundary prefix match, phase3 transition, Adam state preservation under rebuild, wrapper-prefix edge case)
- [x] 3 config-parse tests (each variant composes, `_target_` pointers resolve)
- [x] 5 end-to-end integration tests (snapshot.sample_ids matches datamodule.probe_ids — the sharpest residual risk — full pipeline phase1→fit, seed determinism, staged + control parity)
- [x] Pre-push checklist: `tests/` 570 pass + 15 skip, `manylatents/callbacks/tests/` 17 pass
- [x] `ActivationExtractor` regression: existing 13 `test_hooks.py` tests unchanged

## Context

Precedent in use downstream at [`DrewPhi/manyDiffusionDistillations` PR #3](https://github.com/DrewPhi/manyDiffusionDistillations/pull/3) (merged `0af12c4`), driving the remaining-families smoke that is running right now — 6 runs across pythia_410m, deberta_v3_xsmall, qwen2_5_0_5b × {staged, control_task_only}. The downstream repo had a `manylatents/pipeline/` orchestration layer that scope-creeped into the library (deprecated there; not present upstream). This PR lands the clean core surface so that experiment orchestration can stay in consumer repos where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
