### PR TITLE
Reusable per-layer extraction helper + no-collapse test contracts

### DIFF
--- a/manylatents/lightning/hooks.py
+++ b/manylatents/lightning/hooks.py
@@ -134,6 +134,22 @@ class ActivationExtractor:
         else:
             return tensor
 
+    @classmethod
+    def extract_once(
+        cls, model: nn.Module, forward_fn, layer_specs: List[LayerSpec],
+    ) -> Dict[str, Tensor]:
+        """One-shot capture: register hooks for `layer_specs`, run a single
+        `forward_fn()`, remove the hooks, and return {path: activation}.
+
+        Convenience for single-forward extraction (e.g. encoding one sequence
+        and reading several layers). For repeated/accumulating capture across
+        many forwards, use the capture() context manager directly.
+        """
+        extractor = cls(layer_specs)
+        with extractor.capture(model):
+            forward_fn()
+        return extractor.get_activations()
+
     @contextmanager
     def capture(self, model: nn.Module):
         """Context manager to capture activations during forward pass."""

--- a/manylatents/testing/__init__.py
+++ b/manylatents/testing/__init__.py
@@ -1,0 +1,90 @@
+"""Reusable contracts for model representations.
+
+Plain functions — no pytest, no class hierarchy — so they compose anywhere: in
+unit tests, as runtime assertions on real data, or in a notebook, and across
+manylatents and its extensions (e.g. manylatents.omics encoders).
+
+The headline guard is the "overfit one batch" sanity check for per-layer
+extraction: requesting N layers must yield N *distinct* embeddings. The bug
+this catches produced N identical layers (every layer a copy of one tensor),
+which is invisible unless something asserts the layers actually differ.
+"""
+from __future__ import annotations
+
+from typing import Callable, Mapping
+
+import torch
+from torch import Tensor
+
+__all__ = ["assert_layers_distinct", "assert_per_layer_contract"]
+
+
+def _stack(per_layer: Mapping[object, Tensor]) -> Tensor:
+    """{key: (...,)} → (n_layers, ...) stacked, detached, float, on CPU."""
+    return torch.stack([per_layer[k].detach().float().cpu() for k in per_layer])
+
+
+def assert_layers_distinct(
+    per_layer: Mapping[object, Tensor], *, atol: float = 1e-6,
+) -> None:
+    """Assert a per-layer embedding mapping has not collapsed — i.e. the layers
+    are not identical copies of a single tensor.
+
+    Args:
+        per_layer: {layer_key: tensor} as returned by a multi-layer encoder.
+        atol: max cross-layer std below which layers are treated as identical.
+
+    Raises:
+        AssertionError: if every requested layer is the same within `atol`.
+    """
+    keys = list(per_layer)
+    if len(keys) < 2:
+        return  # nothing to compare
+    spread = _stack(per_layer).std(dim=0)  # per-element std across layers
+    if float(spread.max()) <= atol:
+        raise AssertionError(
+            f"layer collapse: {len(keys)} layers are identical within "
+            f"atol={atol} (max cross-layer std {float(spread.max()):.2e}). "
+            f"Layer keys: {keys}"
+        )
+
+
+def assert_per_layer_contract(
+    encode_fn: Callable[[object], Mapping[object, Tensor]],
+    input_a: object,
+    input_b: object,
+    *,
+    atol: float = 1e-6,
+) -> None:
+    """Full per-layer encoder sanity check on a tiny batch:
+
+      1. encode_fn(input_a) returns a non-empty per-layer mapping;
+      2. its layers are distinct (assert_layers_distinct);
+      3. a different input (input_b) yields different embeddings.
+
+    `encode_fn` must return a Mapping[layer_key -> Tensor].
+
+    Raises:
+        AssertionError: on an empty/non-mapping return, layer collapse, or an
+            encoder that produces identical embeddings for the two inputs.
+    """
+    out_a = encode_fn(input_a)
+    if not isinstance(out_a, Mapping) or not out_a:
+        raise AssertionError(
+            "encode_fn must return a non-empty per-layer mapping; "
+            f"got {type(out_a).__name__}"
+        )
+    assert_layers_distinct(out_a, atol=atol)
+
+    out_b = encode_fn(input_b)
+    shared = [k for k in out_a if k in out_b]
+    if shared and all(
+        torch.allclose(
+            out_a[k].detach().float(), out_b[k].detach().float(), atol=atol
+        )
+        for k in shared
+    ):
+        raise AssertionError(
+            "encoder produced identical embeddings for two different inputs — "
+            "it is not distinguishing inputs"
+        )

--- a/tests/test_layer_contracts.py
+++ b/tests/test_layer_contracts.py
@@ -1,0 +1,97 @@
+"""Tests for manylatents.testing layer contracts + ActivationExtractor.extract_once."""
+import pytest
+import torch
+import torch.nn as nn
+
+from manylatents.testing import assert_layers_distinct, assert_per_layer_contract
+
+
+# --- assert_layers_distinct -------------------------------------------------
+
+def test_distinct_layers_pass():
+    per_layer = {0: torch.randn(2, 4), 1: torch.randn(2, 4), 2: torch.randn(2, 4)}
+    assert_layers_distinct(per_layer)  # should not raise
+
+
+def test_collapsed_layers_raise():
+    shared = torch.randn(2, 4)
+    collapsed = {0: shared, 1: shared.clone(), 2: shared.clone()}
+    with pytest.raises(AssertionError, match="collapse"):
+        assert_layers_distinct(collapsed)
+
+
+def test_single_layer_is_trivially_ok():
+    assert_layers_distinct({0: torch.randn(2, 4)})  # nothing to compare
+
+
+# --- assert_per_layer_contract ----------------------------------------------
+
+def _good_encoder(x):
+    """Distinct per layer AND input-dependent."""
+    base = float(sum(map(ord, x)))
+    return {l: torch.tensor([[base * (l + 1)]]) for l in (0, 1, 2)}
+
+
+def _collapsing_encoder(x):
+    base = torch.tensor([[float(ord(x[0]))]])
+    return {l: base.clone() for l in (0, 1, 2)}
+
+
+def _input_blind_encoder(x):
+    return {l: torch.tensor([[float(l)]]) for l in (0, 1, 2)}
+
+
+def test_contract_passes_for_good_encoder():
+    assert_per_layer_contract(_good_encoder, "MAK", "PAK")
+
+
+def test_contract_catches_layer_collapse():
+    with pytest.raises(AssertionError, match="collapse"):
+        assert_per_layer_contract(_collapsing_encoder, "MAK", "PAK")
+
+
+def test_contract_catches_input_blind_encoder():
+    with pytest.raises(AssertionError, match="distinguishing"):
+        assert_per_layer_contract(_input_blind_encoder, "MAK", "PAK")
+
+
+def test_contract_rejects_non_mapping_return():
+    with pytest.raises(AssertionError, match="mapping"):
+        assert_per_layer_contract(lambda x: torch.zeros(1), "MAK", "PAK")
+
+
+# --- ActivationExtractor.extract_once ---------------------------------------
+
+def test_extract_once_captures_requested_layers():
+    from manylatents.lightning.hooks import ActivationExtractor, LayerSpec
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+
+        def forward(self, x):
+            for b in self.blocks:
+                x = b(x)
+            return x
+
+    net = Net()
+    x = torch.randn(2, 4)
+    specs = [LayerSpec("blocks[0]", reduce="none"),
+             LayerSpec("blocks[2]", reduce="none")]
+    acts = ActivationExtractor.extract_once(net, lambda: net(x), specs)
+    assert set(acts) == {"blocks[0]", "blocks[2]"}
+    assert acts["blocks[0]"].shape == (2, 4)
+    # different blocks → different activations (no accidental aliasing)
+    assert not torch.allclose(acts["blocks[0]"], acts["blocks[2]"])
+
+
+def test_extract_once_removes_hooks():
+    from manylatents.lightning.hooks import ActivationExtractor, LayerSpec
+
+    net = nn.Sequential(nn.Linear(4, 4))
+    ActivationExtractor.extract_once(
+        net, lambda: net(torch.randn(1, 4)), [LayerSpec("0", reduce="none")],
+    )
+    # No forward hooks should remain registered after the one-shot call.
+    assert len(net[0]._forward_hooks) == 0


### PR DESCRIPTION
## What

Two small, additive pieces of reusable infra:

- **`ActivationExtractor.extract_once(model, forward_fn, specs)`** — one-shot capture convenience (register hooks → run one forward → remove hooks → return `{path: tensor}`), so encoders stop hand-rolling forward hooks.
- **`manylatents/testing/`** — plain importable contracts (no pytest/class coupling), reusable across manylatents + extensions:
  - `assert_layers_distinct(per_layer)` — the "overfit one batch" guard: requesting N layers must yield N *distinct* embeddings, not N copies of one tensor.
  - `assert_per_layer_contract(encode_fn, a, b)` — layers present + distinct + different inputs produce different embeddings.

## Why

Caught a downstream encoder layer-collapse bug (every requested "layer" was an identical copy of the final embedding). The flexible primitive (`ActivationExtractor`) already existed; this adds only the contract functions and one thin helper — deliberately no mixin / new class / new reduce mode.

## Tests

`tests/test_layer_contracts.py` covers both contracts + `extract_once`. `uv run pytest` green on the affected suite (hooks + new tests, 22 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)