### PR TITLE
fix: int32 KNN indices for scipy shortest_path; release 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-06-03
+
+### Fixed
+- `compute_geodesic_distances`: cast KNN graph index arrays to int32 before
+  `scipy.sparse.csgraph.shortest_path`, which raised "Buffer dtype mismatch,
+  expected 'const int' but got 'long'" on numpy>=2 / scipy 1.14. Unblocks
+  manylatents-omics' `AdmixturePreservation` metric.
+
 ## [0.1.2] - 2026-02-27
 
 ### Removed

--- a/manylatents/utils/metrics.py
+++ b/manylatents/utils/metrics.py
@@ -273,6 +273,11 @@ def compute_geodesic_distances(embedding, k=10, metric='euclidean', verbose=0):
         embedding, n_neighbors=k, mode='distance',
         metric=metric, include_self=False
     )
+    # scipy's shortest_path Cython kernel expects int32 ('const int') index
+    # arrays; sklearn's kneighbors_graph yields int64 on numpy>=2, which raises
+    # "Buffer dtype mismatch, expected 'const int' but got 'long'". Cast down.
+    knn_graph.indices = knn_graph.indices.astype(np.int32, copy=False)
+    knn_graph.indptr = knn_graph.indptr.astype(np.int32, copy=False)
     n_components, labels = connected_components(knn_graph, directed=False)
     if n_components > 1:
         if verbose:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manylatents"
-version = "0.1.5"
+version = "0.1.6"
 description = "Unified dimensionality reduction and neural network analysis framework"
 license = "MIT"
 authors = [


### PR DESCRIPTION
## Why

`manylatents-omics` CI is red because its `AdmixturePreservation` tests exercise core's `compute_geodesic_distances`, which crashes on numpy≥2 / scipy 1.14:

```
ValueError: Buffer dtype mismatch, expected 'const int' but got 'long'
  at scipy.sparse.csgraph._shortest_path.shortest_path
```

`sklearn.neighbors.kneighbors_graph` returns int64 (`long`) CSR index arrays, but scipy's `shortest_path` Cython kernel expects int32 (`const int`).

## Fix

Cast `knn_graph.indices`/`indptr` to int32 before `shortest_path`. Verified locally (scipy 1.14.1, numpy 2.2.6): the crash is gone and geodesic distances compute correctly.

## Release 0.1.6

Bumps version `0.1.5 → 0.1.6` + changelog. This is the release `manylatents-omics` needs to pin: it bundles this fix **plus** the already-merged `ActivationExtractor.extract_once` and `manylatents.testing` helpers that omics' dogma per-layer tests (PR #44 there) depend on — which aren't in the published 0.1.5. After this merges, tag `v0.1.6` to publish, then omics bumps `manylatents>=0.1.6`.

Publish is tag-gated (`on: push: tags: ['v*']`), so merging this does **not** auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)