### PR TITLE
test: verify latent_ode as a runnable op via run_experiment (#269)

### DIFF
--- a/tests/algorithms/test_latent_ode.py
+++ b/tests/algorithms/test_latent_ode.py
@@ -140,6 +140,7 @@ class TestLatentODELightningModule:
 
         loader = DataLoader(DictDataset(X), batch_size=16)
         trainer = L.Trainer(
+            accelerator="cpu",  # torchdiffeq needs float64; MPS (auto on macOS) has none
             max_epochs=3,
             enable_checkpointing=False,
             enable_progress_bar=False,
@@ -171,3 +172,52 @@ class TestLatentODEHydra:
         net = instantiate(cfg)
         assert isinstance(net, LatentODENetwork)
         assert net.latent_dim == 8
+
+
+class TestLatentODEThroughRunExperiment:
+    """End-to-end: latent_ode as a runnable op via run_experiment (issue #269)."""
+
+    def test_run_experiment_returns_latent_outputs(self):
+        """Toy input -> run_experiment -> assert a non-empty LatentOutputs dict."""
+        import numpy as np
+        from lightning import Trainer
+
+        from manylatents.algorithms.lightning.latent_ode import LatentODE
+        from manylatents.algorithms.lightning.losses.mse import MSELoss
+        from manylatents.algorithms.lightning.networks.latent_ode import LatentODENetwork
+        from manylatents.callbacks.embedding.base import validate_latent_outputs
+        from manylatents.data.precomputed_datamodule import PrecomputedDataModule
+        from manylatents.experiment import run_experiment
+
+        # Toy input: 40 samples x 6 features.
+        X = np.random.default_rng(0).standard_normal((40, 6)).astype("float32")
+        datamodule = PrecomputedDataModule(data=X, seed=0)
+
+        net = LatentODENetwork(
+            input_dim=6, latent_dim=4, hidden_dim=16,
+            encoder_hidden_dims=[16], decoder_hidden_dims=[16], ode_n_layers=1,
+        )
+        model = LatentODE(
+            network=net,
+            optimizer=functools.partial(torch.optim.Adam, lr=1e-3),
+            loss=MSELoss(),
+        )
+
+        # accelerator="cpu" is deliberate: torchdiffeq builds float64 solver
+        # tolerances, which MPS cannot represent. The default accelerator="auto"
+        # would select MPS on macOS and crash. (Captured as M1 friction.)
+        trainer = Trainer(
+            accelerator="cpu", devices=1, max_epochs=1, logger=False,
+            enable_checkpointing=False, enable_progress_bar=False,
+        )
+
+        result = run_experiment(
+            datamodule=datamodule, algorithm=model, trainer=trainer, seed=0
+        )
+
+        # Assert the contract via the codebase's own validator (dict + "embeddings").
+        validate_latent_outputs(result)
+        emb = result["embeddings"]
+        assert emb.ndim == 2, f"expected 2-D embeddings, got shape {emb.shape}"
+        assert emb.shape[0] > 0, "embeddings must be non-empty"
+        assert np.isfinite(emb).all(), "embeddings contain NaN/Inf"


### PR DESCRIPTION
## Summary

Wraps the existing `latent_ode` (`LatentODE` LightningModule) as a runnable, **tested** op through `run_experiment` — the first brick of M2 (#269). **No new production code:** the model and its config-group entry (`latent_ode.yaml`) already exist; this PR adds the end-to-end smoke test that proves the path and pins the `LatentOutputs` contract.

### What this changes
- Adds `TestLatentODEThroughRunExperiment` (`tests/algorithms/test_latent_ode.py`): toy input → `run_experiment` → asserts a non-empty, `LatentOutputs`-shaped dict (via the project's `validate_latent_outputs` plus 2-D / non-empty / finite checks).
- Pins the existing `test_end_to_end_training` Trainer to `accelerator="cpu"` (see friction #3).

### "Done" checklist (#269)
- [x] Runs end-to-end through `run_experiment` on toy data (smoke test: `PrecomputedDataModule` 40×6; also verified on swissroll via CLI)
- [x] Returns standard `LatentOutputs` (`embeddings`/`label`/`metadata`/`scores`) — no bespoke type
- [x] Addressable by name in the single canonical catalog — the `latent_ode.yaml` config group (`algorithms/lightning=latent_ode`)
- [x] One smoke test proving the run
- [x] Friction note (below)

---

## Friction note — where `latent_ode` didn't fit the op surface cleanly (M1 input)

Each item is the model meeting an interface that silently assumes "stateless transform." Captured, not patched (per scope).

1. **By-name resolution is stateless-only.** `api.run(algorithm="latent_ode")` raises `ValueError` (`api.py:158`). The name-miss fallback hardcodes `{"latent": name}` (`api.py:119`), so a bare string can never reach the `lightning` branch. A trained model is addressable only via a `_target_` dict (`api.py:163`) or the Hydra config group (CLI). *(Confirmed with @cmvcordova: bare-name fails; the `_target_`-dict form works today. Wiring lightning by-name forces the op-contract question — M1.)*
2. **Construction asymmetry.** `get_algorithm` returns a bare class and the caller does `cls(random_state=seed)` — fine for stateless modules, impossible for a `LightningModule` that needs network/optimizer/loss/datamodule/trainer.
3. **Hidden device constraint.** `api.run` hardcodes `accelerator="auto"` → MPS on macOS → `torchdiffeq` crashes building float64 solver tolerances (MPS has no float64). The existing `test_end_to_end_training` failed for this on Mac (green in CI/Linux); pinned to CPU here. Stateless ops carry no such constraint.
4. **Input contract is runtime-sniffed.** `shared_step` does `batch["data"] if isinstance(batch, dict) else batch[0]` — no declared input schema; a datamodule using a different key would silently `KeyError`.
5. **Output contract is unenforced + untyped.** `LatentOutputs` is `dict[str, Any]` (`base.py:71`). The keys are magic strings duplicated across two producer sites (`experiment.py:80`, `:271`) and ~8 consumer files, validated at one consumer (`save_outputs.py:82`) and never at the producer (`run_experiment`).
6. **`input_dim` data-coupling.** Auto-inference works only via the config-dict + datamodule path (`setup()`); a pre-built network bypasses it and forces manual dimension matching.
7. **"Time-resolved" needs changes at three layers.** The criterion assumed a time-resolved fixture, but: (a) no time-resolved fixture exists in the repo; (b) swissroll's ground-truth pseudotime (`t`) is computed in the generator but not exposed (`get_labels` returns a blob index); (c) `latent_ode` has no per-sample time input — it integrates a fixed `[0,1]` window for every point, reconstructing static vectors. Making this op genuinely time-resolved requires data → fixture → model changes (M1/beyond).

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
