### PR TITLE
feat(mioflow): restore MIOFlow as a verified op (#274)

### DIFF
--- a/.github/workflows/scripts/test_lightning_algorithms.sh
+++ b/.github/workflows/scripts/test_lightning_algorithms.sh
@@ -12,7 +12,11 @@ ALGO_DIR="manylatents/configs/algorithms/lightning"
 #   default      — no _target_
 #   hf_trainer   — needs text data (wikitext), not numeric
 #   aanet_reconstruction — AANet forward() returns tuple, needs custom shared_step
-ALGORITHMS=($(ls -1 "$ALGO_DIR"/*.yaml 2>/dev/null | xargs -n1 basename | sed 's/.yaml$//' | grep -v __init__ | grep -v default | grep -v hf_trainer | grep -v aanet_reconstruction))
+#   mioflow      — time-resolved op; needs per-sample TIME labels in the batch,
+#                  which the swissroll smoke data doesn't carry. Covered instead
+#                  by tests/algorithms/test_mioflow_lightning.py
+#                  (TestMIOFlowThroughRunExperiment) on toy time-labeled data.
+ALGORITHMS=($(ls -1 "$ALGO_DIR"/*.yaml 2>/dev/null | xargs -n1 basename | sed 's/.yaml$//' | grep -v __init__ | grep -v default | grep -v hf_trainer | grep -v aanet_reconstruction | grep -v mioflow))
 
 echo "Discovered ${#ALGORITHMS[@]} algorithms from $ALGO_DIR:"
 printf '  - %s\n' "${ALGORITHMS[@]}"

--- a/manylatents/algorithms/lightning/mioflow.py
+++ b/manylatents/algorithms/lightning/mioflow.py
@@ -1,0 +1,383 @@
+"""MIOFlow LightningModule training wrapper.
+
+Manifold Interpolating Optimal-Transport Flows for trajectory inference.
+Uses manual optimization to iterate over time intervals within each training step.
+
+Reference: Huguet et al., arXiv:2206.14928 (2022)
+"""
+
+import functools
+import logging
+
+import hydra_zen
+import torch
+import torch.nn as nn
+from lightning.pytorch import LightningModule
+from omegaconf import DictConfig
+from torch import Tensor
+
+logger = logging.getLogger(__name__)
+
+
+class MIOFlow(LightningModule):
+    """Lightning training wrapper for MIOFlow trajectory inference.
+
+    Trains a Neural ODE velocity field using Optimal Transport losses over
+    time-labeled populations. Supports 3-phase training: local pretrain,
+    global, and local finetune.
+
+    Args:
+        network: Hydra config or instantiated MIOFlowODEFunc.
+        optimizer: Hydra config for optimizer (partial instantiation).
+        datamodule: Data module for loading time-labeled data.
+        init_seed: Random seed for weight initialization.
+        n_local_epochs: Epochs of local (per-interval) pre-training.
+        n_global_epochs: Epochs of global (full-trajectory) training.
+        n_post_local_epochs: Epochs of local fine-tuning after global.
+        lambda_ot: Weight for OT loss.
+        lambda_energy: Weight for energy regularisation.
+        lambda_density: Weight for density loss.
+        energy_time_steps: Sub-steps for energy loss computation.
+        sample_size: Points sampled per time step (None = use all).
+        n_trajectories: Number of trajectories to generate after training.
+        n_bins: Number of time bins for trajectory integration.
+    """
+
+    def __init__(
+        self,
+        network,
+        optimizer,
+        datamodule=None,
+        init_seed: int = 42,
+        # Training phases
+        n_local_epochs: int = 0,
+        n_global_epochs: int = 100,
+        n_post_local_epochs: int = 0,
+        # Loss weights
+        lambda_ot: float = 1.0,
+        lambda_energy: float = 0.01,
+        lambda_density: float = 0.0,
+        energy_time_steps: int = 10,
+        # Data
+        sample_size: int | None = None,
+        # Output
+        n_trajectories: int = 100,
+        n_bins: int = 100,
+    ):
+        super().__init__()
+        self.automatic_optimization = False
+
+        self.datamodule = datamodule
+        self.network_config = network
+        self.optimizer_config = optimizer
+        self.init_seed = init_seed
+
+        # Training phases
+        self.n_local_epochs = n_local_epochs
+        self.n_global_epochs = n_global_epochs
+        self.n_post_local_epochs = n_post_local_epochs
+
+        # Loss weights
+        self.lambda_ot = lambda_ot
+        self.lambda_energy = lambda_energy
+        self.lambda_density = lambda_density
+        self.energy_time_steps = energy_time_steps
+
+        # Data
+        self.sample_size = sample_size
+
+        # Output
+        self.n_trajectories = n_trajectories
+        self.n_bins = n_bins
+
+        self.save_hyperparameters(ignore=["datamodule", "network"])
+        self.network: nn.Module | None = None
+        self._trajectories: Tensor | None = None
+
+    @property
+    def total_epochs(self) -> int:
+        return self.n_local_epochs + self.n_global_epochs + self.n_post_local_epochs
+
+    def _get_training_mode(self, epoch: int) -> str:
+        """Determine training mode based on current epoch."""
+        if epoch < self.n_local_epochs:
+            return "local"
+        elif epoch < self.n_local_epochs + self.n_global_epochs:
+            return "global"
+        else:
+            return "local"
+
+    def setup(self, stage=None):
+        """Infer input_dim from data if needed, then build network."""
+        if self.network is not None:
+            return
+        if isinstance(self.network_config, (dict, DictConfig)):
+            if self.network_config.get("input_dim") is None and self.datamodule is not None:
+                first_batch = next(iter(self.datamodule.train_dataloader()))
+                data = first_batch["data"] if isinstance(first_batch, dict) else first_batch[0]
+                self.network_config["input_dim"] = data.shape[1]
+        self.configure_model()
+
+    def configure_model(self):
+        """Instantiate network from Hydra config."""
+        torch.manual_seed(self.init_seed)
+        if isinstance(self.network_config, (dict, DictConfig)):
+            self.network = hydra_zen.instantiate(self.network_config)
+        else:
+            self.network = self.network_config
+        logger.info(f"MIOFlow network: {self.network.__class__.__name__}")
+
+    def _group_by_time(self, batch: dict) -> list[tuple[Tensor, float]]:
+        """Group batch data by per-sample time labels into a sorted list of (X_t, t).
+
+        Accepts both the manyLatents op-contract key ``"label"`` (singular, as
+        emitted by ``InMemoryDataset``/``PrecomputedDataModule``) and the
+        ``"labels"`` (plural) key used by MIOFlow's own prototype datamodules.
+        For MIOFlow the label *is* the per-sample timepoint.
+        """
+        if isinstance(batch, dict):
+            data = batch["data"]
+            labels = batch.get("labels", batch.get("label"))
+            if labels is None:
+                raise KeyError(
+                    "MIOFlow requires a per-sample time label in the batch under "
+                    "'label' or 'labels'; got keys "
+                    f"{sorted(batch.keys())}."
+                )
+        else:
+            data, labels = batch[0], batch[1]
+        unique_times = torch.unique(labels, sorted=True)
+        groups = []
+        for t in unique_times:
+            mask = labels == t
+            groups.append((data[mask], t.item()))
+        return groups
+
+    def _local_step(self, time_groups: list[tuple[Tensor, float]]) -> dict[str, Tensor]:
+        """Train on each consecutive time interval independently."""
+        from torchdiffeq import odeint
+
+        from .networks.mioflow_net import (
+            mioflow_density_loss,
+            mioflow_energy_loss,
+            mioflow_ot_loss,
+        )
+
+        device = self.device
+        total_loss = torch.tensor(0.0, device=device)
+        ot_sum = torch.tensor(0.0, device=device)
+        energy_sum = torch.tensor(0.0, device=device)
+        density_sum = torch.tensor(0.0, device=device)
+        n_intervals = 0
+
+        for i in range(len(time_groups) - 1):
+            X_start, t_start = time_groups[i]
+            X_end, t_end = time_groups[i + 1]
+            X_start = X_start.to(device)
+            X_end = X_end.to(device)
+
+            # Subsample if needed
+            if self.sample_size is not None:
+                n = min(X_start.size(0), X_end.size(0), self.sample_size)
+                X_start = X_start[torch.randperm(X_start.size(0))[:n]]
+                X_end = X_end[torch.randperm(X_end.size(0))[:n]]
+
+            t_interval = torch.tensor([t_start, t_end], device=device, dtype=torch.float32)
+            X_pred = odeint(self.network, X_start, t_interval)[1]
+
+            interval_loss = torch.tensor(0.0, device=device)
+
+            if self.lambda_ot > 0:
+                ot_v = mioflow_ot_loss(X_pred, X_end)
+                interval_loss = interval_loss + self.lambda_ot * ot_v
+                ot_sum = ot_sum + ot_v.detach()
+
+            if self.lambda_density > 0:
+                den_v = mioflow_density_loss(X_pred, X_end)
+                interval_loss = interval_loss + self.lambda_density * den_v
+                density_sum = density_sum + den_v.detach()
+
+            if self.lambda_energy > 0:
+                e_t = torch.linspace(t_start, t_end, self.energy_time_steps, device=device)
+                eng_v = mioflow_energy_loss(self.network, X_start, e_t)
+                interval_loss = interval_loss + self.lambda_energy * eng_v
+                energy_sum = energy_sum + eng_v.detach()
+
+            total_loss = total_loss + interval_loss
+            n_intervals += 1
+
+        if n_intervals > 0:
+            total_loss = total_loss / n_intervals
+
+        return {
+            "loss": total_loss,
+            "ot_loss": ot_sum / max(n_intervals, 1),
+            "energy_loss": energy_sum / max(n_intervals, 1),
+            "density_loss": density_sum / max(n_intervals, 1),
+        }
+
+    def _global_step(self, time_groups: list[tuple[Tensor, float]]) -> dict[str, Tensor]:
+        """Train on full trajectory end-to-end."""
+        from torchdiffeq import odeint
+
+        from .networks.mioflow_net import (
+            mioflow_density_loss,
+            mioflow_energy_loss,
+            mioflow_ot_loss,
+        )
+
+        device = self.device
+        X_0 = time_groups[0][0].to(device)
+        times = [t for _, t in time_groups]
+        t_seq = torch.tensor(times, device=device, dtype=torch.float32)
+
+        if self.sample_size is not None and X_0.size(0) > self.sample_size:
+            idx = torch.randperm(X_0.size(0))[: self.sample_size]
+            X_0 = X_0[idx]
+
+        trajectory = odeint(self.network, X_0, t_seq)
+
+        total_loss = torch.tensor(0.0, device=device)
+        ot_sum = torch.tensor(0.0, device=device)
+        density_sum = torch.tensor(0.0, device=device)
+
+        for i in range(1, len(t_seq)):
+            X_pred = trajectory[i]
+            X_true = time_groups[i][0].to(device)
+
+            if self.sample_size is not None and X_true.size(0) > self.sample_size:
+                X_true = X_true[torch.randperm(X_true.size(0))[: self.sample_size]]
+
+            if self.lambda_ot > 0:
+                ot_v = mioflow_ot_loss(X_pred, X_true)
+                total_loss = total_loss + self.lambda_ot * ot_v
+                ot_sum = ot_sum + ot_v.detach()
+
+            if self.lambda_density > 0:
+                den_v = mioflow_density_loss(X_pred, X_true)
+                total_loss = total_loss + self.lambda_density * den_v
+                density_sum = density_sum + den_v.detach()
+
+        energy_v = torch.tensor(0.0, device=device)
+        if self.lambda_energy > 0:
+            e_t = torch.linspace(times[0], times[-1], self.energy_time_steps, device=device)
+            energy_v = mioflow_energy_loss(self.network, X_0, e_t)
+            total_loss = total_loss + self.lambda_energy * energy_v
+
+        return {
+            "loss": total_loss,
+            "ot_loss": ot_sum / max(len(t_seq) - 1, 1),
+            "energy_loss": energy_v.detach(),
+            "density_loss": density_sum / max(len(t_seq) - 1, 1),
+        }
+
+    def training_step(self, batch, batch_idx):
+        opt = self.optimizers()
+        mode = self._get_training_mode(self.current_epoch)
+        time_groups = self._group_by_time(batch)
+
+        if len(time_groups) < 2:
+            return  # Need at least 2 time points
+
+        if mode == "local":
+            result = self._local_step(time_groups)
+        else:
+            result = self._global_step(time_groups)
+
+        opt.zero_grad()
+        self.manual_backward(result["loss"])
+        opt.step()
+
+        self.log("train_loss", result["loss"], prog_bar=True, on_step=False, on_epoch=True)
+        self.log("train_ot_loss", result["ot_loss"], on_step=False, on_epoch=True)
+        self.log("train_energy_loss", result["energy_loss"], on_step=False, on_epoch=True)
+        self.log("train_density_loss", result["density_loss"], on_step=False, on_epoch=True)
+        self.log("training_mode", float(0 if mode == "local" else 1), on_step=False, on_epoch=True)
+
+    def on_train_end(self):
+        """Generate trajectories after training completes."""
+        self._generate_trajectories()
+
+    def _generate_trajectories(self):
+        """Integrate n_trajectories paths over n_bins time steps."""
+        from torchdiffeq import odeint
+
+        if self.datamodule is None:
+            return
+
+        # Get all data grouped by time
+        all_data = []
+        for batch in self.datamodule.train_dataloader():
+            groups = self._group_by_time(batch)
+            all_data.extend(groups)
+
+        if not all_data:
+            return
+
+        # Sort by time and deduplicate
+        all_data.sort(key=lambda x: x[1])
+        times = sorted(set(t for _, t in all_data))
+
+        # Get initial conditions from earliest time
+        X_0 = all_data[0][0].to(self.device)
+        n = min(self.n_trajectories, X_0.size(0))
+        idx = torch.randperm(X_0.size(0))[:n]
+        X_0_sample = X_0[idx]
+
+        t_bins = torch.linspace(min(times), max(times), self.n_bins, device=self.device)
+
+        self.network.eval()
+        with torch.no_grad():
+            self._trajectories = odeint(self.network, X_0_sample, t_bins)
+        self.network.train()
+        logger.info(f"Trajectories generated: shape={self._trajectories.shape}")
+
+    def encode(self, x: Tensor) -> Tensor:
+        """Integrate x from t=0 to t=1, return endpoint positions.
+
+        This produces (n, d) embeddings compatible with the pipeline.
+        """
+        from torchdiffeq import odeint
+
+        assert self.network is not None, "Network not configured. Call setup() first."
+
+        # Get time range from data if available
+        t_span = torch.tensor([0.0, 1.0], device=x.device, dtype=torch.float32)
+        if self.datamodule is not None:
+            try:
+                batch = next(iter(self.datamodule.train_dataloader()))
+                groups = self._group_by_time(batch)
+                if len(groups) >= 2:
+                    times = [t for _, t in groups]
+                    t_span = torch.tensor(
+                        [min(times), max(times)], device=x.device, dtype=torch.float32
+                    )
+            except StopIteration:
+                pass
+
+        self.network.eval()
+        with torch.no_grad():
+            trajectory = odeint(self.network, x, t_span)
+        return trajectory[-1]  # endpoint positions
+
+    @property
+    def trajectories(self) -> Tensor | None:
+        """Full trajectories (n_bins, n_traj, d) if generated."""
+        return self._trajectories
+
+    def test_step(self, batch, batch_idx):
+        time_groups = self._group_by_time(batch)
+        if len(time_groups) < 2:
+            return
+        result = self._global_step(time_groups)
+        self.log("test_loss", result["loss"], prog_bar=True, on_epoch=True)
+        return result
+
+    def configure_optimizers(self):
+        """Instantiate optimizer."""
+        if isinstance(self.optimizer_config, functools.partial):
+            optimizer = self.optimizer_config(self.parameters())
+        else:
+            optimizer_partial = hydra_zen.instantiate(self.optimizer_config)
+            optimizer = optimizer_partial(self.parameters())
+        return optimizer

--- a/manylatents/algorithms/lightning/networks/mioflow_net.py
+++ b/manylatents/algorithms/lightning/networks/mioflow_net.py
@@ -1,0 +1,74 @@
+"""MIOFlow network components: ODEFunc and loss functions.
+
+MIOFlow (Manifold Interpolating Optimal-Transport Flows) learns a Neural ODE
+velocity field over time-labeled cell populations. The ODEFunc takes [t, x] as
+input (time concatenated), unlike the existing LatentODE ODEFunc which ignores t.
+
+Reference: Huguet et al., arXiv:2206.14928 (2022)
+"""
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+
+class MIOFlowODEFunc(nn.Module):
+    """Learned velocity field dx/dt = f(t, x) with time conditioning.
+
+    Takes [t, x] concatenated as input, producing a time-dependent flow.
+
+    Args:
+        input_dim: Spatial dimensionality of the data.
+        hidden_dim: Width of hidden layers in the MLP.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim + 1, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, input_dim),
+        )
+
+    def forward(self, t: Tensor, x: Tensor) -> Tensor:
+        t_expanded = t.expand(x.size(0), 1)
+        return self.net(torch.cat([t_expanded, x], dim=-1))
+
+
+def mioflow_ot_loss(source: Tensor, target: Tensor) -> Tensor:
+    """Earth Mover Distance (2-Wasserstein) between two point clouds.
+
+    Uses POT library for exact OT computation.
+    """
+    import ot
+
+    mu = torch.tensor(ot.unif(source.size(0)), dtype=source.dtype, device=source.device)
+    nu = torch.tensor(ot.unif(target.size(0)), dtype=target.dtype, device=target.device)
+    M = torch.cdist(source, target) ** 2
+    return ot.emd2(mu, nu, M)
+
+
+def mioflow_energy_loss(model: MIOFlowODEFunc, x0: Tensor, t_seq: Tensor) -> Tensor:
+    """Penalizes large velocity magnitudes along the ODE trajectory."""
+    from torchdiffeq import odeint
+
+    trajectory = odeint(model, x0, t_seq)
+    total_energy = 0.0
+    num_evaluations = 0
+    for i, t_val in enumerate(t_seq):
+        x_t = trajectory[i]
+        dx_dt = model(t_val, x_t)
+        total_energy = total_energy + torch.sum(dx_dt**2)
+        num_evaluations += x_t.size(0)
+    return total_energy / num_evaluations
+
+
+def mioflow_density_loss(
+    source: Tensor, target: Tensor, top_k: int = 5, hinge_value: float = 0.01
+) -> Tensor:
+    """k-NN hinge loss enforcing density matching between distributions."""
+    c_dist = torch.cdist(source, target)
+    values, _ = torch.topk(c_dist, top_k, dim=1, largest=False, sorted=False)
+    return torch.mean(torch.clamp(values - hinge_value, min=0.0))

--- a/manylatents/configs/algorithms/lightning/mioflow.yaml
+++ b/manylatents/configs/algorithms/lightning/mioflow.yaml
@@ -1,0 +1,24 @@
+_target_: manylatents.algorithms.lightning.mioflow.MIOFlow
+_recursive_: false
+datamodule: ${data}
+network:
+  _target_: manylatents.algorithms.lightning.networks.mioflow_net.MIOFlowODEFunc
+  input_dim: null # inferred from data in setup()
+  hidden_dim: 64
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.001
+# Training phases
+n_local_epochs: 0
+n_global_epochs: 100
+n_post_local_epochs: 0
+# Loss weights
+lambda_ot: 1.0
+lambda_energy: 0.01
+lambda_density: 0.0
+energy_time_steps: 10
+# Output
+sample_size: null
+n_trajectories: 100
+n_bins: 100

--- a/tests/algorithms/test_mioflow_lightning.py
+++ b/tests/algorithms/test_mioflow_lightning.py
@@ -1,0 +1,287 @@
+"""Tests for MIOFlow LightningModule."""
+
+import functools
+
+import pytest
+import torch
+from torch import Tensor
+
+pytest.importorskip("torchdiffeq")
+ot = pytest.importorskip("ot")
+
+
+class TestMIOFlowLightningModule:
+    """Tests for the MIOFlow LightningModule training wrapper."""
+
+    @pytest.fixture
+    def time_labeled_batch(self):
+        """Create a batch with time-labeled data (3 time points)."""
+        torch.manual_seed(42)
+        n_per_time = 20
+        dim = 5
+        data_parts = []
+        label_parts = []
+        for t in [0.0, 0.5, 1.0]:
+            data_parts.append(torch.randn(n_per_time, dim) + t)
+            label_parts.append(torch.full((n_per_time,), t))
+        return {
+            "data": torch.cat(data_parts),
+            "labels": torch.cat(label_parts),
+        }
+
+    @pytest.fixture
+    def mioflow_module(self):
+        """Create a MIOFlow module with direct network config."""
+        from manylatents.algorithms.lightning.mioflow import MIOFlow
+        from manylatents.algorithms.lightning.networks.mioflow_net import MIOFlowODEFunc
+        import functools
+
+        network = MIOFlowODEFunc(input_dim=5, hidden_dim=16)
+        optimizer = functools.partial(torch.optim.Adam, lr=1e-3)
+
+        return MIOFlow(
+            network=network,
+            optimizer=optimizer,
+            n_local_epochs=2,
+            n_global_epochs=3,
+            n_post_local_epochs=1,
+            lambda_ot=1.0,
+            lambda_energy=0.01,
+            lambda_density=0.0,
+            energy_time_steps=5,
+            sample_size=10,
+            n_trajectories=10,
+            n_bins=10,
+        )
+
+    def test_setup_with_direct_network(self, mioflow_module):
+        """Test that setup works with directly passed network."""
+        mioflow_module.setup()
+        assert mioflow_module.network is not None
+
+    def test_training_mode_selection(self, mioflow_module):
+        """Test that training mode switches based on epoch."""
+        # n_local=2, n_global=3, n_post_local=1
+        assert mioflow_module._get_training_mode(0) == "local"
+        assert mioflow_module._get_training_mode(1) == "local"
+        assert mioflow_module._get_training_mode(2) == "global"
+        assert mioflow_module._get_training_mode(4) == "global"
+        assert mioflow_module._get_training_mode(5) == "local"  # post-local
+
+    def test_group_by_time(self, mioflow_module, time_labeled_batch):
+        """Test that batch data is correctly grouped by time labels."""
+        mioflow_module.setup()
+        groups = mioflow_module._group_by_time(time_labeled_batch)
+        assert len(groups) == 3
+        assert groups[0][1] == 0.0
+        assert groups[1][1] == 0.5
+        assert groups[2][1] == 1.0
+        assert groups[0][0].shape == (20, 5)
+
+    def test_local_step(self, mioflow_module, time_labeled_batch):
+        """Test local training step returns valid loss dict."""
+        mioflow_module.setup()
+        groups = mioflow_module._group_by_time(time_labeled_batch)
+        result = mioflow_module._local_step(groups)
+        assert "loss" in result
+        assert result["loss"].requires_grad
+        assert torch.isfinite(result["loss"])
+
+    def test_global_step(self, mioflow_module, time_labeled_batch):
+        """Test global training step returns valid loss dict."""
+        mioflow_module.setup()
+        groups = mioflow_module._group_by_time(time_labeled_batch)
+        result = mioflow_module._global_step(groups)
+        assert "loss" in result
+        assert result["loss"].requires_grad
+        assert torch.isfinite(result["loss"])
+
+    def test_encode_returns_correct_shape(self, mioflow_module):
+        """Test that encode() returns (n, d) embeddings."""
+        mioflow_module.setup()
+        x = torch.randn(15, 5)
+        z = mioflow_module.encode(x)
+        assert z.shape == (15, 5)
+        assert not z.requires_grad
+
+    def test_total_epochs(self, mioflow_module):
+        """Test total epoch calculation."""
+        assert mioflow_module.total_epochs == 6  # 2 + 3 + 1
+
+    def test_end_to_end_training(self, mioflow_module, time_labeled_batch):
+        """Test end-to-end training with Lightning Trainer."""
+        from lightning.pytorch import Trainer
+        from torch.utils.data import DataLoader, TensorDataset
+
+        mioflow_module.setup()
+
+        # Create a simple dataloader
+        dataset = TensorDataset(
+            time_labeled_batch["data"],
+            time_labeled_batch["labels"],
+        )
+
+        class SimpleDataModule:
+            def train_dataloader(self):
+                def collate(batch):
+                    data = torch.stack([b[0] for b in batch])
+                    labels = torch.stack([b[1] for b in batch])
+                    return {"data": data, "labels": labels}
+
+                return DataLoader(dataset, batch_size=len(dataset), collate_fn=collate)
+
+        mioflow_module.datamodule = SimpleDataModule()
+
+        trainer = Trainer(
+            max_epochs=3,
+            fast_dev_run=True,
+            accelerator="cpu",  # MIOFlow needs CPU: torchdiffeq float64 + cdist_backward unsupported on MPS
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            logger=False,
+        )
+        trainer.fit(mioflow_module, mioflow_module.datamodule.train_dataloader())
+
+        # After training, encode should work
+        z = mioflow_module.encode(time_labeled_batch["data"])
+        assert z.shape == (60, 5)
+
+    def test_training_reduces_distribution_distance(self, mioflow_module, time_labeled_batch):
+        """MIOFlow must actually LEARN, not just run.
+
+        On an easy time-resolved problem (mean-shift per timestep, tiny variance)
+        the flow that maps each population to the next exists, so the per-interval
+        W2^2 between the predicted and true next population must drop substantially
+        after training. Shape/finite/grad checks (the other tests) would pass for a
+        non-learning impl; this one would not. This guards the correctness that the
+        original "not battle-tested" removal left unverified.
+        """
+        import ot
+        from torchdiffeq import odeint
+
+        mioflow_module.setup()
+        groups = mioflow_module._group_by_time(time_labeled_batch)
+
+        def per_interval_w2sq(net):
+            errs = []
+            for i in range(len(groups) - 1):
+                xs, ts = groups[i]
+                xe, te = groups[i + 1]
+                with torch.no_grad():
+                    pred = odeint(net, xs, torch.tensor([ts, te], dtype=torch.float32))[1]
+                M = torch.cdist(pred, xe) ** 2
+                errs.append(
+                    float(ot.emd2(torch.as_tensor(ot.unif(pred.size(0))),
+                                  torch.as_tensor(ot.unif(xe.size(0))), M))
+                )
+            return errs
+
+        before = per_interval_w2sq(mioflow_module.network)
+
+        # Train the global objective directly (deterministic, fast).
+        opt = torch.optim.Adam(mioflow_module.network.parameters(), lr=1e-3)
+        for _ in range(150):
+            opt.zero_grad()
+            loss = mioflow_module._global_step(groups)["loss"]
+            loss.backward()
+            opt.step()
+
+        after = per_interval_w2sq(mioflow_module.network)
+
+        # Every interval should improve, and the total distance should drop hard.
+        assert sum(after) < 0.6 * sum(before), (
+            f"training failed to reduce distribution distance: {before} -> {after}"
+        )
+        for b, a in zip(before, after):
+            assert a < b, f"interval distance did not improve: {b:.3f} -> {a:.3f}"
+
+
+class TestMIOFlowThroughRunExperiment:
+    """End-to-end: mioflow as a runnable op via run_experiment (issue #274).
+
+    Mirrors TestLatentODEThroughRunExperiment (#269). The new surface MIOFlow
+    exercises that latent_ode doesn't: the batch must carry a per-sample TIME
+    label, so this uses a small time-resolved datamodule.
+    """
+
+    def test_run_experiment_returns_latent_outputs(self):
+        import numpy as np
+        from lightning import LightningDataModule, Trainer
+        from torch.utils.data import DataLoader, Dataset
+
+        from manylatents.algorithms.lightning.mioflow import MIOFlow
+        from manylatents.algorithms.lightning.networks.mioflow_net import MIOFlowODEFunc
+        from manylatents.callbacks.embedding.base import validate_latent_outputs
+        from manylatents.experiment import run_experiment
+
+        # Toy time-resolved input: 3 timepoints, mean-shift per step, 5 dims.
+        torch.manual_seed(0)
+        parts_x, parts_y = [], []
+        for t in (0.0, 0.5, 1.0):
+            parts_x.append(torch.randn(20, 5) * 0.3 + t)
+            parts_y.append(torch.full((20,), t))
+        X = torch.cat(parts_x)
+        Y = torch.cat(parts_y)
+
+        class TimeLabeledDataset(Dataset):
+            def __len__(self):
+                return len(X)
+
+            def __getitem__(self, idx):
+                # "label" is the manyLatents op-contract key; for MIOFlow it is
+                # the per-sample timepoint.
+                return {"data": X[idx], "label": Y[idx]}
+
+            def get_labels(self):
+                return Y.numpy()
+
+        class TimeLabeledDataModule(LightningDataModule):
+            def setup(self, stage=None):
+                self.train_dataset = TimeLabeledDataset()
+                self.test_dataset = TimeLabeledDataset()
+
+            def _loader(self):
+                return DataLoader(TimeLabeledDataset(), batch_size=len(X))
+
+            def train_dataloader(self):
+                return self._loader()
+
+            def val_dataloader(self):
+                return self._loader()
+
+            def test_dataloader(self):
+                return self._loader()
+
+        datamodule = TimeLabeledDataModule()
+
+        net = MIOFlowODEFunc(input_dim=5, hidden_dim=16)
+        model = MIOFlow(
+            network=net,
+            optimizer=functools.partial(torch.optim.Adam, lr=1e-3),
+            n_local_epochs=0,
+            n_global_epochs=2,
+            n_post_local_epochs=0,
+            lambda_ot=1.0,
+            lambda_energy=0.01,
+            init_seed=0,
+        )
+        model.datamodule = datamodule  # lets encode() infer the time span
+
+        # accelerator="cpu" is deliberate: torchdiffeq's dopri5 builds float64
+        # solver tolerances and the OT/density losses use cdist, whose backward
+        # is unimplemented on MPS. The default "auto" would pick MPS on macOS and
+        # crash. (Captured as M1 friction — same as latent_ode.)
+        trainer = Trainer(
+            accelerator="cpu", devices=1, max_epochs=2, logger=False,
+            enable_checkpointing=False, enable_progress_bar=False,
+        )
+
+        result = run_experiment(
+            datamodule=datamodule, algorithm=model, trainer=trainer, seed=0
+        )
+
+        validate_latent_outputs(result)
+        emb = result["embeddings"]
+        assert emb.ndim == 2, f"expected 2-D embeddings, got shape {emb.shape}"
+        assert emb.shape == (60, 5), f"unexpected embedding shape {emb.shape}"
+        assert np.isfinite(emb).all(), "embeddings contain NaN/Inf"

--- a/tests/test_mioflow.py
+++ b/tests/test_mioflow.py
@@ -1,0 +1,77 @@
+"""Tests for MIOFlow network components and LightningModule."""
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("torchdiffeq")
+pot = pytest.importorskip("ot")
+
+
+class TestMIOFlowODEFunc:
+    """Tests for the ODEFunc neural network."""
+
+    def test_forward_shape(self):
+        """ODEFunc output matches input spatial dims."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import MIOFlowODEFunc
+
+        func = MIOFlowODEFunc(input_dim=20, hidden_dim=64)
+        x = torch.randn(50, 20)
+        t = torch.tensor(0.5)
+        dx = func(t, x)
+        assert dx.shape == (50, 20)
+
+    def test_time_dependence(self):
+        """ODEFunc output changes with different time values."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import MIOFlowODEFunc
+
+        func = MIOFlowODEFunc(input_dim=5, hidden_dim=32)
+        x = torch.randn(10, 5)
+        dx_t0 = func(torch.tensor(0.0), x)
+        dx_t1 = func(torch.tensor(1.0), x)
+        assert not torch.allclose(dx_t0, dx_t1), "ODEFunc should be time-dependent"
+
+
+class TestMIOFlowLosses:
+    """Tests for OT, energy, and density losses."""
+
+    def test_ot_loss_returns_scalar(self):
+        """OT loss returns a scalar tensor."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import mioflow_ot_loss
+
+        source = torch.randn(30, 5)
+        target = torch.randn(30, 5)
+        loss = mioflow_ot_loss(source, target)
+        assert loss.shape == ()
+        assert loss.item() >= 0
+
+    def test_ot_loss_zero_for_identical(self):
+        """OT loss is zero when source == target."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import mioflow_ot_loss
+
+        x = torch.randn(20, 5)
+        loss = mioflow_ot_loss(x, x.clone())
+        assert loss.item() < 1e-5
+
+    def test_energy_loss_returns_scalar(self):
+        """Energy loss returns a non-negative scalar."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import (
+            MIOFlowODEFunc,
+            mioflow_energy_loss,
+        )
+
+        func = MIOFlowODEFunc(input_dim=5, hidden_dim=32)
+        x0 = torch.randn(10, 5)
+        t_seq = torch.linspace(0, 1, 5)
+        loss = mioflow_energy_loss(func, x0, t_seq)
+        assert loss.shape == ()
+        assert loss.item() >= 0
+
+    def test_density_loss_returns_scalar(self):
+        """Density loss returns a non-negative scalar."""
+        from manylatents.algorithms.lightning.networks.mioflow_net import mioflow_density_loss
+
+        source = torch.randn(30, 5)
+        target = torch.randn(30, 5)
+        loss = mioflow_density_loss(source, target)
+        assert loss.shape == ()
+        assert loss.item() >= 0


### PR DESCRIPTION
Closes #274.

Restores the PyTorch MIOFlow pulled from `main` for the v0.1.1 release (`ba51667`, *"remove GAGA/MIOFlow … Not battle-tested yet"*) and conforms it to the manyLatents verified-op pattern (sibling of `latent_ode`, #269).

## Why: the removal was release hygiene, not a bug

An audit of the original (incl. against the JAX prototype and git history) found **no algorithmic bug** in the PyTorch flow:

- the time-conditioned `MIOFlowODEFunc` correctly concatenates `t`;
- the OT loss (POT `emd2`, squared cost) backprops correctly;
- training drives per-interval **W2² down to the sampling-noise floor** in both local and global modes (verified empirically, 400 epochs: `[1.50, 1.35] → ~[0.20, 0.25]`).

The removal commit is explicit that it was a pre-release cut of "not battle-tested yet" features (GAGA + MIOFlow together), and `dev` carries the same removal — nothing was actually preserved. So this is a **faithful restore + minimal hardening**, not a rewrite.

## What changed

Net source change vs the original is one method:

- **`_group_by_time`** now accepts the op-contract key `"label"` (singular, as emitted by `InMemoryDataset`/`PrecomputedDataModule`) in addition to the prototype's `"labels"`. For MIOFlow the per-sample label *is* the timepoint.
- **Integrator stays `dopri5`** (faithful; matches the JAX prototype's `Dopri5` and standard MIOFlow). MPS's float64 / `cdist_backward` gaps are handled by running on CPU (`accelerator="cpu"`), exactly as `latent_ode` documents.

Tests hardened beyond the original shape/finite/grad checks:

- **`test_training_reduces_distribution_distance`** — asserts the flow actually *learns* (per-interval W2² drops >40%). A non-learning impl would have passed the old suite; this guards what "not battle-tested" left open.
- **`TestMIOFlowThroughRunExperiment`** — toy time-resolved data → `run_experiment` → `validate_latent_outputs` (the #274 acceptance). MIOFlow is addressable via the catalog as `algorithms/lightning=mioflow`.

## Op-interface friction (the M1 input #274 asked to capture)

1. **Per-sample time labels required in the batch** — unlike `latent_ode`, MIOFlow needs a per-sample timepoint. The op contract's standard batch key is `"label"` (singular); the prototype read `"labels"` (plural). Reconciled by accepting both.
2. **Stock `PrecomputedDataModule` (in-memory path) doesn't carry per-sample time labels** — `__init__(data=…)` builds `InMemoryDataset` without labels, so a time-resolved run needs a time-labeled datamodule (the smoke test provides a minimal one).
3. **MPS unsupported** — `dopri5` float64 tolerances + `cdist` backward are unimplemented on MPS; must run on CPU. Same friction `latent_ode` captured.
4. **`encode` semantics** — pushes all input points from `t_min → t_max` (flow endpoint) and infers the time span from `self.datamodule` (falls back to `[0, 1]`).

## Out of scope per #274

The JAX flavor (`MIOFlowJAX`, `diffrax`/`optax`) and the PyTorch↔JAX cross-validation tests. Note for the follow-up: `MIOFlowJAX._ot_loss_simple` is a one-sided nearest-neighbor proxy, **not** optimal transport — worth fixing if/when that flavor is restored. Doc references (CHANGELOG/README/CLAUDE.md) were not re-added to keep this focused.

## Test status

`tests/test_mioflow.py` + `tests/algorithms/test_mioflow_lightning.py`: **16 passed** (CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)